### PR TITLE
Rely on PATH for linuxsampler location

### DIFF
--- a/zyngine/zynthian_engine_linuxsampler.py
+++ b/zyngine/zynthian_engine_linuxsampler.py
@@ -83,7 +83,7 @@ class zynthian_engine_linuxsampler(zynthian_engine):
 
 		self.sock=None
 		self.port=6688
-		self.command=("/usr/bin/linuxsampler", "--lscp-port", str(self.port))
+		self.command=("linuxsampler", "--lscp-port", str(self.port))
 		os.environ["LADSPA_PATH"]="/usr/lib64/ladspa"
 
 		self.ls_chans={}


### PR DESCRIPTION
This future-proofs the switch to linuxsampler-2 by finding the binary
whether it is installed in /usr/bin or /usr/local/bin from a source
install.