### PR TITLE
Updated zynthian_gui_engine.py

### DIFF
--- a/zyngui/zynthian_gui_engine.py
+++ b/zyngui/zynthian_gui_engine.py
@@ -57,7 +57,7 @@ class zynthian_gui_engine(zynthian_gui_selector):
 		["BF", ("setBfree","setBfree - Hammond Emulator")],
 	])
 
-	if check_pianoteq_binary():
+	if get_pianoteq_binary_info():
 		if PIANOTEQ_TRIAL:
 			engine_info['PT']=(PIANOTEQ_NAME,"Pianoteq Stage - Demo")
 		else:


### PR DESCRIPTION
Corrected the call to get_pianoteq_binary_info so that it correctly identifies the installed version of Pianoteq.