### PR TITLE
Fix path to pedalboards

### DIFF
--- a/zyngine/zynthian_engine_modui.py
+++ b/zyngine/zynthian_engine_modui.py
@@ -71,7 +71,7 @@ class zynthian_engine_modui(zynthian_engine):
 
 		self.bank_dirs = [
 			('EX', self.ex_data_dir + "/mod-pedalboards"),
-			('_', self.my_data_dir + "/mod-pedalboards")
+			('_', self.my_data_dir + "/presets/mod-ui/pedalboards")
 		]
 		self.hw_ports = {}
 


### PR DESCRIPTION
The zynthian-my-data layout has changed recently, this fixes the path
so that the MD preset screen is populated with pedalboards