### PR TITLE
Sleep between calls to amixer

### DIFF
--- a/zyngine/zynthian_engine_mixer.py
+++ b/zyngine/zynthian_engine_mixer.py
@@ -297,6 +297,7 @@ class zynthian_engine_mixer(zynthian_engine):
 
 			logging.debug(amixer_command)
 			check_output(shlex.split(amixer_command))
+			sleep(0.05)
 
 		except Exception as err:
 			logging.error(err)


### PR DESCRIPTION
My zynthian-ui was restarting without any useful logging whenever I loaded an
engine (tried mod-ui and linuxsampler).

I bisected the problem to commit 15eafb95cbaf680bf66aa1f0846da98a85bb6649,
shlex seems to be parsing the amixer commands just fine.

Logging the amixer output showed that some amixer commands didn't return an
output, but check_output also didn't raise any exception. Adding a sleep
between amixer calls seems to fix this issue for me.