### PR TITLE
Sanitize jack plugin names when launching jalv

### DIFF
--- a/zyngine/zynthian_engine_jalv.py
+++ b/zyngine/zynthian_engine_jalv.py
@@ -168,7 +168,10 @@ class zynthian_engine_jalv(zynthian_engine):
 		except:
 			jname_count = 0
 
-		jname = "{}-{:02d}".format(plugin_name, jname_count) 
+                # Jack, when listing ports, accepts regular expressions as the jack name. There's no way to match
+                # literal strings. So, it's most convenient when jack names don't contain regex characters.
+                # Also, spaces in the name are no good (unless we rework the launching command below).
+		jname = "{}-{:02d}".format(plugin_name.replace("*","_").replace("[","").replace("]","").replace(" ",""), jname_count)
 
 		self.learned_cc = [[None for c in range(128)] for chan in range(16)]
 		self.learned_zctrls = {}


### PR DESCRIPTION
Jack plugin names sometimes contain spaces, stars (`*`), and other nice characters. Unfortunately, Python's jack client (and probably jack itself) matches regular expressions when doing a [`get_ports`](https://github.com/spatialaudio/jackclient-python/blob/master/src/jack.py#L1552) call. Because of this, zynthian gets terribly confused when dealing with e.g. the included _C* Scape - Stereo delay + Filters_ plugin.

This commits removes spaces, starts, and other regex-impacting characters from the plugin name before turning it into the name passed to Jack. This allows those plugins to now be used in an FX chain.

It does affect the name in the FX Chain UI as well; there may be a nicer way, but it'd require:
- properly passing the arguments to `jalv` as an array, rather than a string
- quoting jack names as proper regular expressions in all calls to `get_ports` (and perhaps others)

I found this solution to be a good short-term fix; let me know what you think.