### PR TITLE
Show class for LV2 effects when selecting (+ more)

### DIFF
--- a/zyngine/zynthian_controller.py
+++ b/zyngine/zynthian_controller.py
@@ -373,6 +373,7 @@ class zynthian_controller:
 				self.set_midi_learn(int(snapshot['midi_learn_chan']), int(snapshot['midi_learn_cc']))
 		else:
 			self.set_value(snapshot,True)
+		self.refresh_gui()
 
 
 	#--------------------------------------------------------------------------
@@ -530,6 +531,9 @@ class zynthian_controller:
 	def midi_control_change(self, val):
 		value=self.value_min+val*self.value_range/127
 		self.set_value(value)
+		self.refresh_gui()
+
+	def refresh_gui(self):
 		#Refresh GUI controller in screen when needed ...
 		try:
 			if (self.engine.zyngui.active_screen=='control' or self.engine.zyngui.modal_screen=='control') and self.engine.zyngui.screens['control'].mode=='control':

--- a/zyngine/zynthian_layer.py
+++ b/zyngine/zynthian_layer.py
@@ -534,27 +534,31 @@ class zynthian_layer:
 		zs3 = self.zs3_list[i]
 
 		if zs3:
-			#Load bank list and set bank
-			self.load_bank_list()
-			self.set_bank_by_name(zs3['bank_name'])
-			self.wait_stop_loading()
+			# For non-LV2 engines, bank and preset can affect what controllers do.
+			# In case of LV2, just restoring the controllers ought to be enough, which is nice
+			# since it saves the 0.3 second delay between setting a preset and updating controllers.
+			if not self.engine.nickname.startswith('JV'):
+				#Load bank list and set bank
+				self.load_bank_list()
+				self.set_bank_by_name(zs3['bank_name'])
+				self.wait_stop_loading()
 
-			#Load preset list and set preset
-			self.load_preset_list()
-			self.set_preset_by_name(zs3['preset_name'])
-			self.wait_stop_loading()
+				#Load preset list and set preset
+				self.load_preset_list()
+				self.set_preset_by_name(zs3['preset_name'])
+				self.wait_stop_loading()
 
-			#Refresh controller config
-			if self.refresh_flag:
-				self.refresh_flag=False
-				self.refresh_controllers()
+				#Refresh controller config
+				if self.refresh_flag:
+					self.refresh_flag=False
+					self.refresh_controllers()
+				sleep(0.3)
 
 			#Set active screen
 			if 'active_screen_index' in zs3:
 				self.active_screen_index=zs3['active_screen_index']
 
 			#Set controller values
-			sleep(0.3)
 			for k in zs3['controllers_dict']:
 				self.controllers_dict[k].restore_snapshot(zs3['controllers_dict'][k])
 

--- a/zyngine/zynthian_lv2.py
+++ b/zyngine/zynthian_lv2.py
@@ -30,6 +30,7 @@ import time
 import string
 import logging
 import contextlib
+import re
 
 from enum import Enum
 from collections import OrderedDict
@@ -139,6 +140,7 @@ def generate_plugins_config_file(refresh=True):
 			genplugins[name] = {
 				'URL': str(plugin.get_uri()),
 				'TYPE': get_plugin_type(plugin).value,
+				'CLASS': re.sub(' Plugin', '', str(plugin.get_class().get_label())),
 				'ENABLED': is_plugin_enabled(name)
 			}
 

--- a/zyngui/zynthian_gui_engine.py
+++ b/zyngui/zynthian_gui_engine.py
@@ -74,7 +74,7 @@ class zynthian_gui_engine(zynthian_gui_selector):
 			cls.engine_info['PT'] = (PIANOTEQ_NAME, pianoteq_title, "MIDI Synth", zynthian_engine_pianoteq, True)
 
 		for plugin_name, plugin_info in get_jalv_plugins().items():
-			cls.engine_info['JV/{}'.format(plugin_name)] = (plugin_name, "{} - Plugin LV2".format(plugin_name), plugin_info['TYPE'], zynthian_engine_jalv, plugin_info['ENABLED'])
+			cls.engine_info['JV/{}'.format(plugin_name)] = (plugin_name, "{} - {}".format(plugin_info.get('CLASS',''), plugin_name), plugin_info['TYPE'], zynthian_engine_jalv, plugin_info['ENABLED'])
 
 		cls.engine_info['PD'] = ("PureData", "PureData - Visual Programming", "Special", zynthian_engine_puredata, True)
 		cls.engine_info['CS'] = ("CSound", "CSound Audio Language", "Special", zynthian_engine_csound, False)
@@ -103,7 +103,8 @@ class zynthian_gui_engine(zynthian_gui_selector):
 		self.index=0
 		self.list_data=[]
 		i=0
-		for en, info in self.engine_info.items():
+		# Sort by second element (index 1) of the value of the map (which is the displayed name)
+		for en, info in sorted(self.engine_info.items(), key=lambda kv: kv[1][1]):
 			if (info[4] and (info[2]==self.engine_type or self.engine_type is None) and
 				(en not in self.single_layer_engines or en not in self.zyngines)):
 

--- a/zyngui/zynthian_gui_layer.py
+++ b/zyngui/zynthian_gui_layer.py
@@ -51,10 +51,12 @@ class zynthian_gui_layer(zynthian_gui_selector):
 		self.add_layer_eng = None
 		self.replace_layer_index = None
 		self.last_snapshot_fpath = None
+		self.last_zs3_index = [0] * 16; # Last selected ZS3 snapshot, per MIDI channel
 		super().__init__('Layer', True)
 
 
 	def reset(self):
+		self.last_zs3_index = [0] * 16; # Last selected ZS3 snapshot, per MIDI channel
 		self.show_all_layers = False
 		self.add_layer_eng = None
 		self.last_snapshot_fpath = None
@@ -409,12 +411,15 @@ class zynthian_gui_layer(zynthian_gui_selector):
 		for layer in self.layers:
 			if zynthian_gui_config.midi_single_active_channel or midich==layer.get_midi_chan():
 				if layer.restore_zs3(zs3_index) and not selected:
+					self.last_zs3_index[midich] = zs3_index
 					try:
 						self.select_action(self.root_layers.index(layer))
 						selected = True
 					except Exception as e:
 						logging.error("Can't select layer => {}".format(e))
 
+	def get_last_zs3_index(self, midich):
+		return self.last_zs3_index[midich]
 
 	def save_midi_chan_zs3(self, midich, zs3_index):
 		for layer in self.layers:

--- a/zyngui/zynthian_gui_zs3_learn.py
+++ b/zyngui/zynthian_gui_zs3_learn.py
@@ -49,10 +49,13 @@ class zynthian_gui_zs3_learn(zynthian_gui_selector):
 		#Add list of programs
 		midich=self.zyngui.curlayer.get_midi_chan()
 		zs3_indexes=self.zyngui.screens['layer'].get_midi_chan_zs3_used_indexes(midich)
+		select_zs3_idx = self.zyngui.screens['layer'].get_last_zs3_index(midich)
 		self.num_programs=len(zs3_indexes)
 		for i, zs3_index in enumerate(zs3_indexes):
 			zs3_title="Program {}".format(zs3_index)
 			self.list_data.append((zs3_index,len(self.list_data),zs3_title))
+			if zs3_index == select_zs3_idx:
+				self.index = len(self.list_data) - 1
 
 		#Add "Waiting for Program Change" message
 		if len(self.list_data)>0:


### PR DESCRIPTION
This provides a convenient sorting and better discoverability for LV2 effects, especially if more than a few are enabled from the web UI.

For the moment, the class is displayed only as a prefix, but it might be better to create nice sub-headings for these, as is done on other screens.

It'd also be nice to eventually categorize the webconf this way as well.

---

_UPDATE_: This PR now also contains various other fixes / improvements I've been working on. See individual commit messages for details.

The commits themselves are quite small and can be reviewed individually, but please let me know if you'd like a different PR for some of them.