### PR TITLE
Configure input capture channels for a layer

### DIFF
--- a/zyngui/__init__.py
+++ b/zyngui/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
 	"zynthian_gui_midi_cc",
 	"zynthian_gui_transpose",
 	"zynthian_gui_audio_out",
+	"zynthian_gui_audio_in",
 	"zynthian_gui_midi_out",
 	"zynthian_gui_bank",
 	"zynthian_gui_preset",
@@ -42,6 +43,7 @@ from zyngui.zynthian_gui_midi_chan import zynthian_gui_midi_chan
 from zyngui.zynthian_gui_midi_cc import zynthian_gui_midi_cc
 from zyngui.zynthian_gui_transpose import zynthian_gui_transpose
 from zyngui.zynthian_gui_audio_out import zynthian_gui_audio_out
+from zyngui.zynthian_gui_audio_in import zynthian_gui_audio_in
 from zyngui.zynthian_gui_midi_out import zynthian_gui_midi_out
 from zyngui.zynthian_gui_bank import zynthian_gui_bank
 from zyngui.zynthian_gui_preset import zynthian_gui_preset

--- a/zyngui/zynthian_gui_audio_in.py
+++ b/zyngui/zynthian_gui_audio_in.py
@@ -1,0 +1,81 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#******************************************************************************
+# ZYNTHIAN PROJECT: Zynthian GUI
+# 
+# Zynthian GUI Audio-In Selector Class
+# 
+#******************************************************************************
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of
+# the License, or any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# For a full copy of the GNU General Public License see the LICENSE.txt file.
+# 
+#******************************************************************************
+
+import sys
+import tkinter
+import logging
+
+# Zynthian specific modules
+import zynautoconnect
+from . import zynthian_gui_config
+from . import zynthian_gui_selector
+
+#------------------------------------------------------------------------------
+# Zynthian Audio-Out Selection GUI Class
+#------------------------------------------------------------------------------
+
+class zynthian_gui_audio_in(zynthian_gui_selector):
+
+	def __init__(self):
+		self.layer=None
+		super().__init__('Audio In', True)
+
+
+	def set_layer(self, layer):
+		self.layer = layer
+		self.audio_in_variants = layer.suggest_audio_in_list()
+
+	def fill_list(self):
+		self.list_data = []
+
+		for idx, variant in enumerate(self.audio_in_variants):
+			config = variant[1]
+			if self.layer.audio_in == config:
+				title = "[X] {}".format(variant[0])
+				self.index = idx
+			else:
+				title = "[  ] {}".format(variant[0])
+			self.list_data.append((idx, idx, title))
+                
+		super().fill_list()
+
+
+	def fill_listbox(self):
+		super().fill_listbox()
+
+	def select_action(self, i, t='S'):
+		self.layer.set_audio_in(self.audio_in_variants[self.list_data[i][1]][1])
+		self.fill_list()
+
+	def back_action(self):
+		self.zyngui.show_modal('layer_options')
+		return ''
+
+
+	def set_select_path(self):
+		if self.layer and self.layer.get_basepath():
+			self.select_path.set("Audio capture for {}".format(self.layer.get_basepath()))
+		else:
+			self.select_path.set("Audio Routing ...")
+
+#------------------------------------------------------------------------------

--- a/zyngui/zynthian_gui_layer_options.py
+++ b/zyngui/zynthian_gui_layer_options.py
@@ -114,7 +114,8 @@ class zynthian_gui_layer_options(zynthian_gui_selector):
 				self.list_data.append((self.layer_midi_routing, None, "MIDI Routing"))
 
 			if 'audio_route' in eng_options and eng_options['audio_route']:
-				self.list_data.append((self.layer_audio_routing, None, "Audio Routing"))
+				self.list_data.append((self.layer_audio_input, None, "Audio Capture"))
+				self.list_data.append((self.layer_audio_routing, None, "Audio Output"))
 
 			if 'midi_chan' in eng_options and eng_options['midi_chan']:
 				self.list_data.append((self.layer_midi_chan, None, "MIDI Channel"))
@@ -282,7 +283,10 @@ class zynthian_gui_layer_options(zynthian_gui_selector):
 	def layer_audio_routing(self):
 		self.zyngui.screens['audio_out'].set_layer(self.layer)
 		self.zyngui.show_modal('audio_out')
-
+		
+	def layer_audio_input(self):
+		self.zyngui.screens['audio_in'].set_layer(self.layer)
+		self.zyngui.show_modal('audio_in')
 
 	def layer_remove(self):
 		self.zyngui.screens['layer'].remove_root_layer(self.layer_index)

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -62,6 +62,7 @@ from zyngui.zynthian_gui_midi_chan import zynthian_gui_midi_chan
 from zyngui.zynthian_gui_midi_cc import zynthian_gui_midi_cc
 from zyngui.zynthian_gui_transpose import zynthian_gui_transpose
 from zyngui.zynthian_gui_audio_out import zynthian_gui_audio_out
+from zyngui.zynthian_gui_audio_in import zynthian_gui_audio_in
 from zyngui.zynthian_gui_midi_out import zynthian_gui_midi_out
 from zyngui.zynthian_gui_bank import zynthian_gui_bank
 from zyngui.zynthian_gui_preset import zynthian_gui_preset
@@ -314,6 +315,7 @@ class zynthian_gui:
 		self.screens['midi_cc'] = zynthian_gui_midi_cc()
 		self.screens['transpose'] = zynthian_gui_transpose()
 		self.screens['audio_out'] = zynthian_gui_audio_out()
+		self.screens['audio_in'] = zynthian_gui_audio_in()
 		self.screens['midi_out'] = zynthian_gui_midi_out()
 		self.screens['bank'] = zynthian_gui_bank()
 		self.screens['preset'] = zynthian_gui_preset()


### PR DESCRIPTION
This commit adds the ability to configure which capture inputs route to
the top input on an effects layer.

Internally, this is stored in a "audio_in" dict that precisely specifies
which capture inputs are connected to which LV2 input(s).

To the user, a simplified list of mono / stereo choices are provided,
depending on the number of capture inputs and number of LV2 inputs.

Supersedes #253 and implements the "simple UI" idea from there.

**TODO**
- [ ] Load and save `audio_in` in snapshot state, once agreed on the format
- [ ] Remove extraneous debugging lines and exception catching