### PR TITLE
Implement on-screen buttons

### DIFF
--- a/zyngui/zynthian_gui_base.py
+++ b/zyngui/zynthian_gui_base.py
@@ -103,6 +103,54 @@ class zynthian_gui_base:
 		# Configure Topbar's Frame column widths
 		#self.tb_frame.grid_columnconfigure(0, minsize=self.path_canvas_width)
 
+		self.button_push_ts = 0
+
+	def init_touchbar(self):
+		# Touchbar frame
+		if not zynthian_gui_config.enable_touch_widgets:
+			return
+
+		self.touch_frame = tkinter.Frame(self.main_frame,
+		width=zynthian_gui_config.display_width,
+		height=zynthian_gui_config.touchbar_height,
+		bg=zynthian_gui_config.color_bg)
+		self.touch_frame.grid(row=3, column=0, columnspan=3)
+		self.touch_frame.grid_propagate(False)
+		for i in range(4):
+			self.touch_frame.grid_columnconfigure(
+				i, minsize=zynthian_gui_config.button_width)
+
+		self.add_button(0, 0, 'Layer')
+		self.add_button(1, 2, 'Snapshot')
+		self.add_button(2, 1, 'Back')
+		self.add_button(3, 3, 'Select')
+
+	def add_button(self, column, index, label):
+		select_button = tkinter.Button(
+			self.touch_frame,
+			bg=zynthian_gui_config.color_bg,
+			fg=zynthian_gui_config.color_header_tx,
+			activebackground=zynthian_gui_config.color_bg,
+			activeforeground=zynthian_gui_config.color_header_tx,
+			text=label)
+		select_button.grid(row=0, column=column, sticky='we')
+		select_button.bind('<ButtonPress-1>', lambda e: self.button_down(index, e))
+		select_button.bind('<ButtonRelease-1>', lambda e: self.button_up(index, e))
+
+	def button_down(self, index, event):
+		self.button_push_ts=datetime.now()
+
+	def button_up(self, index, event):
+		t = 'S'
+		if self.button_push_ts:
+			dts=(datetime.now()-self.button_push_ts).total_seconds()
+			if dts<0.3:
+				t = 'S'
+			elif dts>=0.3 and dts<2:
+				t = 'B'
+			elif dts>=2:
+				t = 'L'
+		self.zyngui.zynswitch_defered(t,index)
 
 	def show(self):
 		if not self.shown:

--- a/zyngui/zynthian_gui_config.py
+++ b/zyngui/zynthian_gui_config.py
@@ -465,6 +465,7 @@ try:
 			display_height=240
 
 	ctrl_width = display_width//4
+	button_width = display_width//4
 	topbar_height = display_height//10
 	touchbar_height = enable_touch_widgets and display_height//5 or 0
 	body_height = display_height-topbar_height-touchbar_height

--- a/zyngui/zynthian_gui_config.py
+++ b/zyngui/zynthian_gui_config.py
@@ -256,20 +256,6 @@ except:
 # UI Geometric Parameters
 #------------------------------------------------------------------------------
 
-# Screen Size => Autodetect if None
-if os.environ.get('DISPLAY_WIDTH'):
-	display_width=int(os.environ.get('DISPLAY_WIDTH'))
-	ctrl_width=int(display_width/4)
-else:
-	display_width=None
-
-if os.environ.get('DISPLAY_HEIGHT'):
-	display_height=int(os.environ.get('DISPLAY_HEIGHT'))
-	topbar_height=int(display_height/10)
-	ctrl_height=int((display_height-topbar_height)/2)
-else:
-	display_height=None
-
 # Controller Positions
 ctrl_pos=[
 	(1,0,"nw"),
@@ -459,22 +445,30 @@ try:
 
 	top = tkinter.Tk()
 
-	# Try to autodetect screen size if not configured
-	try:
-		if not display_width:
+	# Screen Size => Autodetect if None
+	if os.environ.get('DISPLAY_WIDTH'):
+		display_width=int(os.environ.get('DISPLAY_WIDTH'))
+	else:
+		try:
 			display_width = top.winfo_screenwidth()
-			ctrl_width = int(display_width/4)
-		if not display_height:
+		except:
+			logging.warning("Can't get screen width. Using default 320!")
+			display_width=320
+
+	if os.environ.get('DISPLAY_HEIGHT'):
+		display_height=int(os.environ.get('DISPLAY_HEIGHT'))
+	else:
+		try:
 			display_height = top.winfo_screenheight()
-			topbar_height = int(display_height/10)
-			ctrl_height = int((display_height-topbar_height)/2)
-	except:
-		logging.warning("Can't get screen size. Using default 320x240!")
-		display_width = 320
-		display_height = 240
-		topbar_height = int(display_height/10)
-		ctrl_width = int(display_width/4)
-		ctrl_height = int((display_height-topbar_height)/2)
+		except:
+			logging.warning("Can't get screen height. Using default 240!")
+			display_height=240
+
+	ctrl_width = display_width//4
+	topbar_height = display_height//10
+	touchbar_height = enable_touch_widgets and display_height//5 or 0
+	body_height = display_height-topbar_height-touchbar_height
+	ctrl_height = body_height//2
 
 	# Adjust font size, if not defined
 	if not font_size:

--- a/zyngui/zynthian_gui_patterneditor.py
+++ b/zyngui/zynthian_gui_patterneditor.py
@@ -84,7 +84,7 @@ class zynthian_gui_patterneditor():
 
 		# Geometry vars
 		self.width=zynthian_gui_config.display_width
-		self.height=zynthian_gui_config.display_height - zynthian_gui_config.topbar_height
+		self.height=zynthian_gui_config.body_height
 		self.selectThickness = 1 + int(self.width / 500) # Scale thickness of select border based on screen resolution
 		self.gridHeight = self.height - PLAYHEAD_HEIGHT
 		self.gridWidth = int(self.width * 0.9)

--- a/zyngui/zynthian_gui_selector.py
+++ b/zyngui/zynthian_gui_selector.py
@@ -143,6 +143,9 @@ class zynthian_gui_selector(zynthian_gui_base.zynthian_gui_base):
 		self.loading_canvas.bind("<Button-1>",self.cb_loading_push)
 		self.loading_canvas.bind("<ButtonRelease-1>",self.cb_loading_release)
 
+		# Init touchbar
+		self.init_touchbar()
+
 		# Setup Loading Logo Animation
 		self.loading_index=0
 		self.loading_item=self.loading_canvas.create_image(3, 3, image = zynthian_gui_config.loading_imgs[0], anchor=tkinter.NW)

--- a/zyngui/zynthian_gui_selector.py
+++ b/zyngui/zynthian_gui_selector.py
@@ -57,7 +57,7 @@ class zynthian_gui_selector(zynthian_gui_base.zynthian_gui_base):
 		self.select_path_dir=2
 
 		# Listbox Size
-		self.lb_height=zynthian_gui_config.display_height-zynthian_gui_config.topbar_height
+		self.lb_height=zynthian_gui_config.body_height
 		self.wide=wide
 		if self.wide:
 			self.lb_width=zynthian_gui_config.display_width-zynthian_gui_config.ctrl_width

--- a/zyngui/zynthian_gui_seqtrigger.py
+++ b/zyngui/zynthian_gui_seqtrigger.py
@@ -61,7 +61,7 @@ class zynthian_gui_seqtrigger():
 
 		# Geometry vars
 		self.width=zynthian_gui_config.display_width
-		self.height=zynthian_gui_config.display_height - zynthian_gui_config.topbar_height
+		self.height=zynthian_gui_config.body_height
 		self.selectThickness = 1 + int(self.width / 500) # Scale thickness of select border based on screen
 		self.colWidth = self.width / self.columns
 		self.rowHeight = self.height / self.rows

--- a/zyngui/zynthian_gui_songeditor.py
+++ b/zyngui/zynthian_gui_songeditor.py
@@ -78,7 +78,7 @@ class zynthian_gui_songeditor():
 
 		# Geometry vars
 		self.width=zynthian_gui_config.display_width
-		self.height=zynthian_gui_config.display_height - zynthian_gui_config.topbar_height
+		self.height=zynthian_gui_config.body_height
 		self.selectThickness = 1 + int(self.width / 500) # Scale thickness of select border based on screen resolution
 		self.gridHeight = self.height - PLAYHEAD_HEIGHT
 		self.gridWidth = int(self.width * 0.9)


### PR DESCRIPTION
This change shows 4 buttons across the bottom of the screen when
enable_touch_widgets is true (this is now option "Enable Touch Widgets" in the
webconf User Interface page)

Short/firm/long pushes are implemented, the button order for now is
Layer, Snapshot, Back, Select