### PR TITLE
buttonbar tweaks

### DIFF
--- a/zyngui/zynthian_gui_base.py
+++ b/zyngui/zynthian_gui_base.py
@@ -24,6 +24,7 @@
 #******************************************************************************
 
 import sys
+import datetime
 import logging
 import tkinter
 from tkinter import font as tkFont
@@ -119,11 +120,13 @@ class zynthian_gui_base:
 		for i in range(4):
 			self.touch_frame.grid_columnconfigure(
 				i, minsize=zynthian_gui_config.button_width)
+		self.touch_frame.grid_rowconfigure(
+			0, minsize=zynthian_gui_config.touchbar_height)
 
-		self.add_button(0, 0, 'Layer')
-		self.add_button(1, 2, 'Snapshot')
-		self.add_button(2, 1, 'Back')
-		self.add_button(3, 3, 'Select')
+		self.add_button(0, 1, 'BACK')
+		self.add_button(1, 0, 'LAYER')
+		self.add_button(2, 2, 'SNAPSHOT')
+		self.add_button(3, 3, 'SELECT')
 
 	def add_button(self, column, index, label):
 		select_button = tkinter.Button(
@@ -132,6 +135,7 @@ class zynthian_gui_base:
 			fg=zynthian_gui_config.color_header_tx,
 			activebackground=zynthian_gui_config.color_bg,
 			activeforeground=zynthian_gui_config.color_header_tx,
+			padx=0,
 			text=label)
 		select_button.grid(row=0, column=column, sticky='we')
 		select_button.bind('<ButtonPress-1>', lambda e: self.button_down(index, e))

--- a/zyngui/zynthian_gui_config.py
+++ b/zyngui/zynthian_gui_config.py
@@ -467,7 +467,7 @@ try:
 	ctrl_width = display_width//4
 	button_width = display_width//4
 	topbar_height = display_height//10
-	touchbar_height = enable_touch_widgets and display_height//5 or 0
+	touchbar_height = enable_touch_widgets and display_height//6 or 0
 	body_height = display_height-topbar_height-touchbar_height
 	ctrl_height = body_height//2
 


### PR DESCRIPTION
- make height 1/6 of screen height instead of 1/5
- add missing datetime import
- reorder buttons, make labels capital
- attempt to get buttons to claim full height of bar (don't think it worked)