### PR TITLE
Fix MIDI learning for value-based controllers

### DIFF
--- a/zyngui/zynthian_gui_controller.py
+++ b/zyngui/zynthian_gui_controller.py
@@ -566,7 +566,7 @@ class zynthian_gui_controller:
 	def zctrl_sync(self):
 		#List of values (value selector)
 		if self.selmode:
-			val=self.zctrl.get_label2index()
+			val=self.zctrl.get_value2index()
 		if self.zctrl.labels:
 			#logging.debug("ZCTRL SYNC LABEL => {}".format(self.zctrl.get_value2label()))
 			val=self.zctrl.get_label2value(self.zctrl.get_value2label())


### PR DESCRIPTION
Commit b49696d broke MIDI learning of value-based controllers, probably
because of a typo. Trying to MIDI learn a value-based controller results
in this "error" message in the log:
```
DEBUG:zynthian_controller: 'zynthian_controller' object has no attribute 'get_label2index'
```
This commit seems to fix that, by replacing the method call with what I
think was intended.