### PR TITLE
Try to add setBfree manuals on consecutive MIDI channels

### DIFF
--- a/zyngine/zynthian_engine_setbfree.py
+++ b/zyngine/zynthian_engine_setbfree.py
@@ -272,7 +272,10 @@ class zynthian_engine_setbfree(zynthian_engine):
 			if self.manuals_config[4][0]:
 				try:
 					# Adding Lower Manual Layer
-					midi_chans[1] = free_chans.pop(0)
+					if midi_chans[0] + 1 in free_chans:
+						midi_chans[1] = midi_chans[0] + 1
+					else:
+						midi_chans[1] = free_chans.pop(0)
 					logging.info("Lower Manual Layer in chan {}".format(midi_chans[1]))
 					self.zyngui.screens['layer'].add_layer_midich(midi_chans[1], False)
 					self.layers[1].bank_name = "Lower"
@@ -285,7 +288,10 @@ class zynthian_engine_setbfree(zynthian_engine):
 			if self.manuals_config[4][1]:
 				try:
 					# Adding Pedal Layer
-					midi_chans[2] = free_chans.pop(0)
+					if midi_chans[0] + 2 in free_chans:
+						midi_chans[2] = midi_chans[0] + 2
+					else:
+						midi_chans[2] = free_chans.pop(0)
 					logging.info("Pedal Layer in chan {}".format(midi_chans[2]))
 					self.zyngui.screens['layer'].add_layer_midich(midi_chans[2], False)
 					i=len(self.layers)-1


### PR DESCRIPTION
Old behaviour: Adding setBfree will load the first manual to the requested MIDI channel then load subsequent manuals to the first free channels which may be lower, non-consecutive channels, e.g. MIDI channels: 5, 2, 3.
This patch attempts to load each manual of the setBfree engine on consecutive MIDI channels, falling back  to old behaviour of first available MIDI channel if consecutive channels are not available.