### PR TITLE
Fix Celtic Harp group ID

### DIFF
--- a/zyngine/zynthian_engine_pianoteq.py
+++ b/zyngine/zynthian_engine_pianoteq.py
@@ -248,7 +248,7 @@ class zynthian_engine_pianoteq(zynthian_engine):
 	]
 
 	bank_list_v6_6 = [
-        	('Celtic Harp', 0, 'Celtic Harp', 'Celtic Harp:A')
+        	('Celtic Harp', 0, 'Celtic Harp', 'Harp:A')
 	]
 
 	bank_list_v6_5 = [


### PR DESCRIPTION
Problem: Celtic harp was showing in 'demo items' when bought and licensed

Fix: change the group ID to the correct value