### PR TITLE
Feature/touchscreen calibration

### DIFF
--- a/zyngui/zynthian_gui_admin.py
+++ b/zyngui/zynthian_gui_admin.py
@@ -141,6 +141,7 @@ class zynthian_gui_admin(zynthian_gui_selector):
 		self.list_data.append((self.test_audio,0,"Test Audio"))
 		self.list_data.append((self.test_midi,0,"Test MIDI"))
 		self.list_data.append((None,0,"-----------------------------"))
+		self.list_data.append((self.zyngui.calibrate_touchscreen,0,"Calibrate Touchscreen"))
 		self.list_data.append((self.update_software,0,"Update Software"))
 		#self.list_data.append((self.update_system,0,"Update Operating System"))
 		self.list_data.append((None,0,"-----------------------------"))

--- a/zyngui/zynthian_gui_touchscreen_calibration.py
+++ b/zyngui/zynthian_gui_touchscreen_calibration.py
@@ -160,6 +160,7 @@ class zynthian_gui_touchscreen_calibration:
 	#	Set the device to configure
 	#	name: Device name
 	def setDevice(self, name):
+		#TODO: The evdev name and xinput name do not necessarily match - we could use evdev to set values
 		self.device_name = name
 		self.canvas.itemconfig(self.device_text, text=name)
 		#TODO: Do we need to set ctm here?
@@ -180,6 +181,7 @@ class zynthian_gui_touchscreen_calibration:
 	#	Handle touch press event
 	#	event: Event including x,y coordinates
 	def onPress(self, event):
+		#TODO: First calibration does not stop countdown
 		self.canvas.itemconfig("crosshairs_lines", fill="red")
 		self.canvas.itemconfig("crosshairs_circles", outline="red")
 		self.pressed = True
@@ -191,6 +193,7 @@ class zynthian_gui_touchscreen_calibration:
 		self.canvas.itemconfig("crosshairs_lines", fill="white")
 		self.canvas.itemconfig("crosshairs_circles", outline="white")
 		self.pressed = False
+		self.countdown = self.timeout
 		if not self.device_name:
 				return
 		if self.index < 2:

--- a/zyngui/zynthian_gui_touchscreen_calibration.py
+++ b/zyngui/zynthian_gui_touchscreen_calibration.py
@@ -363,6 +363,8 @@ class zynthian_gui_touchscreen_calibration:
 			self.shown=True
 			self.device_name = None
 			self.ctm = None
+			self.canvas.unbind('<Button-1>')
+			self.canvas.unbind('<ButtonRelease-1>')
 			self.canvas.itemconfig(self.countdown_text, text="Closing in %ds" % (self.timeout))
 			self.canvas.itemconfig(self.device_text, text="")
 			self.countdown = self.timeout

--- a/zyngui/zynthian_gui_touchscreen_calibration.py
+++ b/zyngui/zynthian_gui_touchscreen_calibration.py
@@ -72,13 +72,14 @@ class zynthian_gui_touchscreen_calibration:
 			bd=0,
 			highlightthickness=0)
 		self.canvas.bind('<ButtonRelease-1>', self.onRelease)
+		self.canvas.bind('<Button-1>', self.onPress)
 		
 		# Instruction text
 		self.instruction_text = self.canvas.create_text(self.width / 2,
 			self.height / 2 - zynthian_gui_config.font_size * 2,
 			font=(zynthian_gui_config.font_family,zynthian_gui_config.font_size,"normal"),
 			fill="white",
-			text="Touch each cross as it appears")
+			text="Touch screen to detect and start calibration")
 
 		# Countdown timer
 		self.countdown_text = self.canvas.create_text(self.width / 2,
@@ -91,47 +92,73 @@ class zynthian_gui_touchscreen_calibration:
 		# Coordinate transform matrix
 		self.transform_matrix = [1,0,0, 0,1,0, 0,0,1]
 		self.identify_matrix = [1,0,0, 0,1,0, 0,0,1]
-		self.display_points = [point(self.width * 0.15, self.height * 0.15), point(self.width * 0.5, self.height * 0.85), point(self.width * 0.85, self.height * 0.5)]
-		self.touch_points = [point(), point(), point()]
+		self.display_points = [point(self.width * 0.15, self.height * 0.15), point(self.width * 0.85, self.height * 0.15), point(self.width * 0.85, self.height * 0.85), point(self.width * 0.15, self.height * 0.85)]
+		self.touch_points = [point(), point(), point(), point()]
 		self.touch_min = point()
 		self.touch_max = point()
 
 		# Crosshair
-		self.index = 0 # Index of current calibration point (0=NE, 1=S, 2=E)
+		self.index = 0 # Index of current calibration point (0=NW, 1=NE, 2=SE, 3=SW)
 		self.crosshair_size = self.width / 20 # half width of cross hairs
 		self.crosshair_vertical = self.canvas.create_line(
 			self.display_points[self.index].x, self.display_points[self.index].y - self.crosshair_size,
 			self.display_points[self.index].x, self.display_points[self.index].y - self.crosshair_size,
-			fill="white")
+			fill="white", state=tkinter.HIDDEN, tags="crosshairs")
 		self.crosshair_horizontal = self.canvas.create_line(
 			self.display_points[self.index].x - self.crosshair_size, self.display_points[self.index].y,
 			self.display_points[self.index].x + self.crosshair_size, self.display_points[self.index].y,
-			fill="white")
+			fill="white", state=tkinter.HIDDEN, tags="crosshairs")
 		#TODO: Add circle to crosshairs?
 
 		self.canvas.pack()
-		self.device_name = None
+		self.device_name = None # Name of selected device
+		self.devices = {} # Dictionary of device properties indexed by device name
 
+	
+	#	Handle touch event
+	#	event: Event including x,y coordinates
+	def onPress(self, event):
+		self.countdown = 5 # Reset countdown timer when screen touched
+		if not self.device_name:
+			self.index = 0
+			self.detectTouchscreens()
+			for device in self.devices:
+				self.setCalibration(device, self.identify_matrix)
+				#TODO: Reset any devices that we don't use back to their previous state
+	
 	
 	#	Handle touch release event
 	#	event: Event including x,y coordinates
 	def onRelease(self, event):
 		self.countdown = 5 # Reset countdown timer when screen touched
-		if(self.index < 3):
+		if not self.device_name:
+			for device in self.devices:
+				last_touch = self.getLastTouch(device)
+				if last_touch.x != 0 or last_touch.y != 0:
+					self.device_name = device
+				else:
+					self.setCalibration(device, self.devices[device]["ctm"]) # Reset calibration of other devices that we changed during detection
+			if self.device_name:
+				self.canvas.itemconfig(self.instruction_text, text="Calibrating %s\nTouch each crosshair. Measurement taken when released"%(self.device_name))
+				self.index = 0
+				self.drawCross()
+			return
+		if self.index < 4:
 			self.touch_points[self.index].x = event.x
 			self.touch_points[self.index].y = event.y
-		self.index += 1
-		if self.index > 2:
+			print(self.display_points[self.index].x, self.display_points[self.index].y, event.x, event.y)
+			self.index += 1
+		if self.index > 3:
 			if self.calcCalibrationMatrix():
-				self.setCalibration(self.transform_matrix, True)
+				self.setCalibration(self.device_name, self.transform_matrix, True)
 			#TODO: Allow user to check calibration
 			self.hide()
 		self.drawCross()
 
 	
-	#	Draws the crosshairs for touch registration for current index (0..2)
+	#	Draws the crosshairs for touch registration for current index (0..3)
 	def drawCross(self):
-		if self.index > 2:
+		if self.index > 3:
 			return
 		self.canvas.coords(self.crosshair_vertical,
 			self.display_points[self.index].x, self.display_points[self.index].y - self.crosshair_size,
@@ -139,79 +166,132 @@ class zynthian_gui_touchscreen_calibration:
 		self.canvas.coords(self.crosshair_horizontal,
 			self.display_points[self.index].x - self.crosshair_size, self.display_points[self.index].y,
 			self.display_points[self.index].x + self.crosshair_size, self.display_points[self.index].y)
+		self.canvas.itemconfig("crosshairs", state=tkinter.NORMAL)
 
 
-	#	Get the name and parameters for the first touchscreen detected
-	#	TODO: Allow configuration of other touchscreens, not just first
-	def getFirstTouchscreen(self):
-		self.device_name = None
+	#	Get last touch coordinates from device
+	#	Returns point object with last touch coordinates
+	def getLastTouch(self, device):
+		try:
+			result = run(["xinput", "--query-state", device], stdout=PIPE).stdout.decode()
+			a = result.find("valuator[0]")
+			b = result.find("\n", a)
+			x = int(result[a+12:b])
+			a = result.find("valuator[1]")
+			b = result.find("\n", a)
+			y = int(result[a+12:b])
+		except:
+			logging.warning("Failed to detect touchscreen last touch")
+			return point(0,0)
+		return point(x,y)
+
+	#	Populate list of touchscreens with relevant properties
+	def detectTouchscreens(self):
+		self.devices = {}
 		result = run(["xinput", "--list", "--name-only"], stdout=PIPE).stdout.decode().split("\n")
 		# Get properties and check for calibration option
+		for device in result:
+			if device == "":
+				continue
+			properties = run(["xinput", "--list", "--long", device], stdout=PIPE).stdout.decode()
+			if properties.find("master pointer") > 0:
+				continue; # Don't want the master device
+			if properties.find("Type: XITouchClass") > 0:
+				config = {}
+				status = run(["xinput", "--query-state", device], stdout=PIPE).stdout.decode()
+				a = properties.find("Abs MT Position X")
+				b = properties.find("Range:", a)
+				c = properties.find("\n",b)
+				d = properties[b+7:c]
+				e = d.split(" - ")
+				min_x = float(e[0])
+				max_x = float(e[1])
+				a = properties.find("Abs MT Position Y")
+				b = properties.find("Range:", a)
+				c = properties.find("\n",b)
+				d = properties[b+7:c]
+				e = d.split(" - ")
+				min_y = float(e[0])
+				max_y = float(e[1])
+				config["min"] = point(min_x,min_y)
+				config["max"] = point(max_x,max_y)
+				config["ctm"] = self.getMatrix(device)
+				self.devices[device] = config
+
+
+	#	Get the current calibration settings for a device
+	#	device: Name or ID of device
+	#	Returns: Coordinate Transformation Matrix or None on error
+	def getMatrix(self, device):
+		result = run(["xinput", "--list-props", device], stdout=PIPE).stdout.decode()
+		a = result.find("Coordinate Transformation Matrix")
+		b = result.find(":", a)
+		c = result.find("\n", b)
+		if not (b > a and c > b):
+			return None
+		str_matrix = result[b+2:c].split(",")
+		if len(str_matrix) != 9:
+			return None
+		matrix = []
 		try:
-			for device in result:
-				if device == "":
-					continue
-				properties = run(["xinput", "--list", "--long", device], stdout=PIPE).stdout.decode()
-				if properties.find("master pointer") > 0:
-					continue; # Don't want the master device
-				if properties.find("Type: XITouchClass") > 0:
-					a = properties.find("Abs MT Position X")
-					b = properties.find("Range:", a)
-					c = properties.find("\n",b)
-					d = properties[b+7:c]
-					e = d.split(" - ")
-					self.touch_min.x = float(e[0])
-					self.touch_max.x = float(e[1])
-					a = properties.find("Abs MT Position Y")
-					b = properties.find("Range:", a)
-					c = properties.find("\n",b)
-					d = properties[b+7:c]
-					e = d.split(" - ")
-					self.touch_min.y = float(e[0])
-					self.touch_max.y = float(e[1])
-					self.device_name = device
-		except Exception as e:
-			logging.warning("Failed to find touchscreen for calibration", e)
+			for value in str_matrix:
+				matrix.append(float(value))
+		except:
+			return None
+		return matrix
 
 
 	# 	Calculate calibration matrix from previously populated display and touch points
 	#	Returns: True on success
 	def calcCalibrationMatrix(self):
-		Divider = (((self.touch_points[0].x - self.touch_points[2].x) * (self.touch_points[1].y - self.touch_points[2].y)) -
+		# Get average coords for corners of touch rectangle
+		touch_min_x = (self.touch_points[0].x + self.touch_points[3].x) / 2
+		touch_max_x = (self.touch_points[1].x + self.touch_points[2].x) / 2
+		touch_min_y = (self.touch_points[0].y + self.touch_points[1].y) / 2
+		touch_max_y = (self.touch_points[2].y + self.touch_points[3].y) / 2
+		touch_width = touch_max_x - touch_min_x
+		touch_height = touch_max_y - touch_min_y
+		self.transform_matrix[0] = touch_width / self.width
+		self.transform_matrix[4] = touch_height / self.height
+		self.transform_matrix[2] = touch_min_x / self.width
+		self.transform_matrix[5] = touch_min_y / self.height
+		return True
+		
+		divider = (((self.touch_points[0].x - self.touch_points[2].x) * (self.touch_points[1].y - self.touch_points[2].y)) -
 			((self.touch_points[1].x - self.touch_points[2].x) * (self.touch_points[0].y - self.touch_points[2].y)))
-		if Divider == 0:
+		if divider == 0:
 			return False
-		self.transform_matrix[0] = (((self.display_points[0].x - self.display_points[2].x) * (self.touch_points[1].y - self.touch_points[2].y)) - 
-			((self.display_points[1].x - self.display_points[2].x) * (self.touch_points[0].y - self.touch_points[2].y)))
-		self.transform_matrix[1] = (((self.touch_points[0].x - self.touch_points[2].x) * (self.display_points[1].x - self.display_points[2].x)) - 
-			((self.display_points[0].x - self.display_points[2].x) * (self.touch_points[1].x - self.touch_points[2].x)))
-		self.transform_matrix[2] = ((self.touch_points[2].x * self.display_points[1].x - self.touch_points[1].x * self.display_points[2].x) * self.touch_points[0].y +
+		self.transform_matrix[0] = (((self.display_points[0].x - self.display_points[2].x) * (self.touch_points[1].y - self.touch_points[2].y) - 
+			(self.display_points[1].x - self.display_points[2].x) * (self.touch_points[0].y - self.touch_points[2].y)) / divider)
+		self.transform_matrix[1] = (((self.touch_points[0].x - self.touch_points[2].x) * (self.display_points[1].x - self.display_points[2].x) - 
+			(self.display_points[0].x - self.display_points[2].x) * (self.touch_points[1].x - self.touch_points[2].x)) / divider)
+		self.transform_matrix[2] = (((self.touch_points[2].x * self.display_points[1].x - self.touch_points[1].x * self.display_points[2].x) * self.touch_points[0].y +
 			(self.touch_points[0].x * self.display_points[2].x - self.touch_points[2].x * self.display_points[0].x) * self.touch_points[1].y +
-			(self.touch_points[1].x * self.display_points[0].x - self.touch_points[0].x * self.display_points[1].x) * self.touch_points[2].y)
-		self.transform_matrix[3] = (((self.display_points[0].y - self.display_points[2].y) * (self.touch_points[1].y - self.touch_points[2].y)) - 
-			((self.display_points[1].y - self.display_points[2].y) * (self.touch_points[0].y - self.touch_points[2].y)))
-		self.transform_matrix[4] = (((self.touch_points[0].x - self.touch_points[2].x) * (self.display_points[1].y - self.display_points[2].y)) - 
-			((self.display_points[0].y - self.display_points[2].y) * (self.touch_points[1].x - self.touch_points[2].x)))
-		self.transform_matrix[5] = ((self.touch_points[2].x * self.display_points[1].y - self.touch_points[1].x * self.display_points[2].y) * self.touch_points[0].y +
+			(self.touch_points[1].x * self.display_points[0].x - self.touch_points[0].x * self.display_points[1].x) * self.touch_points[2].y) / divider)
+		self.transform_matrix[3] = ((((self.display_points[0].y - self.display_points[2].y) * (self.touch_points[1].y - self.touch_points[2].y)) - 
+			((self.display_points[1].y - self.display_points[2].y) * (self.touch_points[0].y - self.touch_points[2].y))) / divider)
+		self.transform_matrix[4] = ((((self.touch_points[0].x - self.touch_points[2].x) * (self.display_points[1].y - self.display_points[2].y)) - 
+			((self.display_points[0].y - self.display_points[2].y) * (self.touch_points[1].x - self.touch_points[2].x))) / divider)
+		self.transform_matrix[5] = (((self.touch_points[2].x * self.display_points[1].y - self.touch_points[1].x * self.display_points[2].y) * self.touch_points[0].y +
 			(self.touch_points[0].x * self.display_points[2].y - self.touch_points[2].x * self.display_points[0].y) * self.touch_points[1].y +
-			(self.touch_points[1].x * self.display_points[0].y - self.touch_points[0].x * self.display_points[1].y) * self.touch_points[2].y)
+			(self.touch_points[1].x * self.display_points[0].y - self.touch_points[0].x * self.display_points[1].y) * self.touch_points[2].y) / divider)
 		return True
 
 
 	#	Apply screen calibration
+	#	device: Name or ID of device to calibrate
 	#	matrix: Transorm matrix as 9 element array (3x3)
 	#	write_file: True to write configuration to file (default: false)
-	def setCalibration(self, matrix, write_file=False):
+	def setCalibration(self, device, matrix, write_file=False):
 		try:
-			proc = run(["xinput", "--set-prop", self.device_name, "Coordinate Transformation Matrix",
-				str(matrix[0]), str(matrix[1]), str(matrix[2]), str(matrix[3]), str(matrix[4]), str(matrix[5]), "0", "0", "1"])
-			#logging.debug("***setCalibration: ", proc.args)
+			proc = run(["xinput", "--set-prop", device, "Coordinate Transformation Matrix",
+				str(matrix[0]), str(matrix[1]), str(matrix[2]), str(matrix[3]), str(matrix[4]), str(matrix[5]), str(matrix[6]), str(matrix[7]), str(matrix[8])])
 			if write_file:
 				# Create config file
 				f = open("/etc/X11/xorg.conf.d/99-calibration.conf", "w")
 				f.write('Section "InputClass"\n')
 				f.write('	Identifier "calibration"\n')
-				f.write('	MatchProduct "%s"\n'%(self.device_name))
+				f.write('	MatchProduct "%s"\n'%(device))
 				f.write('	Option "TransformationMatrix" "%f %f %f %f %f %f 0 0 1"\n' % (matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5]))
 				f.write('EndSection\n')
 				f.close()
@@ -222,6 +302,8 @@ class zynthian_gui_touchscreen_calibration:
 	#	Hide display
 	def hide(self):
 		if self.shown:
+			self.canvas.itemconfig("crosshairs", state=tkinter.HIDDEN)
+			self.canvas.itemconfig(self.instruction_text, text="Touch screen to detect and start calibration")
 			self.shown=False
 			self.timer.cancel()
 			self.main_frame.grid_forget()
@@ -232,16 +314,10 @@ class zynthian_gui_touchscreen_calibration:
 	def show(self):
 		if not self.shown:
 			self.shown=True
+			self.device_name = None
 			self.canvas.itemconfig(self.countdown_text, text="Closing in 5s")
 			self.countdown= 5
-			self.getFirstTouchscreen()
-			if not self.device_name:
-				logging.warning("No touchscreen detected")
-				self.hide() #TODO: This does not close screen
-				return
-			self.setCalibration(self.identify_matrix) # Clear calibration
 			self.index = 0
-			self.drawCross()
 			self.main_frame.grid()
 			self.onTimer()
 

--- a/zyngui/zynthian_gui_touchscreen_calibration.py
+++ b/zyngui/zynthian_gui_touchscreen_calibration.py
@@ -26,15 +26,15 @@
 import tkinter
 import logging
 import tkinter.font as tkFont
-from PIL import Image, ImageTk
-from threading import Timer
+from threading import Timer, Thread
 from subprocess import run,PIPE
 from datetime import datetime # Only to timestamp config file updates
+from evdev import InputDevice, ecodes
+from select import select
+import os
 
 # Zynthian specific modules
 from . import zynthian_gui_config
-
-import time
 
 # Little class to represent x,y coordinates
 class point:
@@ -58,7 +58,7 @@ class zynthian_gui_touchscreen_calibration:
 		self.zyngui=zynthian_gui_config.zyngui
 		self.height = zynthian_gui_config.display_height
 		self.width = zynthian_gui_config.display_width
-		self.debounce = 0.1 * self.height
+		self.debounce = 0.5 * self.height # Touches cannot be closer than this
 
 		# Main Frame
 		self.main_frame = tkinter.Frame(zynthian_gui_config.top,
@@ -74,8 +74,6 @@ class zynthian_gui_touchscreen_calibration:
 			bg="black",
 			bd=0,
 			highlightthickness=0)
-		self.canvas.bind('<ButtonRelease-1>', self.onRelease)
-		self.canvas.bind('<Button-1>', self.onPress)
 		
 		# Instruction text
 		self.instruction_text = self.canvas.create_text(self.width / 2,
@@ -94,10 +92,10 @@ class zynthian_gui_touchscreen_calibration:
 			font=(zynthian_gui_config.font_family,zynthian_gui_config.font_size,"normal"),
 			fill="red")
 		self.timer = Timer(interval=1, function=self.onTimer)
-		self.timeout = 7 # Period in seconds after last touch until sceen closes with no change
+		self.timeout = 15 # Period in seconds after last touch until sceen closes with no change
+		self.pressed = False # True if screen pressed
 		
 		# Coordinate transform matrix
-		self.transform_matrix = [1,0,0, 0,1,0, 0,0,1]
 		self.identify_matrix = [1,0,0, 0,1,0, 0,0,1]
 		self.display_points = [point(self.width * 0.15, self.height * 0.15), point(self.width * 0.85, self.height * 0.85)]
 		self.touch_points = [point(), point()]
@@ -108,92 +106,128 @@ class zynthian_gui_touchscreen_calibration:
 		self.crosshair_circle = self.canvas.create_oval(
 			self.display_points[self.index].x - self.crosshair_size * 0.8, self.display_points[self.index].y - self.crosshair_size * 0.8,
 			self.display_points[self.index].x + self.crosshair_size * 0.8, self.display_points[self.index].y + self.crosshair_size * 0.8,
-			width=3, outline="white", tags="crosshairs")
+			width=3, outline="white", tags=("crosshairs","crosshairs_circles"))
 		self.crosshair_inner_circle = self.canvas.create_oval(
 			self.display_points[self.index].x - self.crosshair_size * 0.2, self.display_points[self.index].y - self.crosshair_size * 0.2,
 			self.display_points[self.index].x + self.crosshair_size * 0.2, self.display_points[self.index].y + self.crosshair_size * 0.2,
-			width=3, outline="white", tags="crosshairs")
+			width=3, outline="white", tags=("crosshairs","crosshairs_circles"))
 		self.crosshair_vertical = self.canvas.create_line(
 			self.display_points[self.index].x, self.display_points[self.index].y - self.crosshair_size,
 			self.display_points[self.index].x, self.display_points[self.index].y - self.crosshair_size,
-			width=3, fill="white", tags="crosshairs")
+			width=3, fill="white", tags=("crosshairs","crosshairs_lines"))
 		self.crosshair_horizontal = self.canvas.create_line(
 			self.display_points[self.index].x - self.crosshair_size, self.display_points[self.index].y,
 			self.display_points[self.index].x + self.crosshair_size, self.display_points[self.index].y,
-			width=3, fill="white", tags="crosshairs")
+			width=3, fill="white", tags=("crosshairs","crosshairs_lines"))
 		
 		self.canvas.pack()
 		self.device_name = None # Name of selected device
-		self.devices = {} # Dictionary of device properties indexed by device name
+		self.ctm = [0.0 for i in range(9)] # Coordinate Transformation Matrix
 
+
+	#	Run xinput
+	#	args: List of arguments to pass to xinput
+	#	Returns: Output of xinput as string
+	#	Credit: https://github.com/reinderien/xcalibrate
+	def xinput(self, *args):
+		return run(args=('/usr/bin/xinput', *args),
+			stdout=PIPE, check=True,
+			universal_newlines=True).stdout
+
+
+	#	Tread waiting for first touch to detect touch interface
+	def detectDevice(self):
+		# Populate list of absolute x/y devices
+		devices = []
+		for filename in os.listdir("/dev/input"):
+			if filename.startswith("event"):
+				device = InputDevice("/dev/input/%s" % (filename))
+				if ecodes.EV_ABS in device.capabilities().keys():
+					devices.append(device)
+		# Loop until we get a touch button event or the view hides
+		running = True
+		while running and self.shown:
+			r, w, x = select(devices, [], []) # Wait for any of the devices to trigger an event
+			for device in r: # Iterate through all devices that have triggered events
+				for event in device.read(): # Iterate through all events from each device
+					if event.code == ecodes.BTN_TOUCH: #TODO: Handle other button press - can we use ecode.BTN?
+						self.setDevice(device.name)
+						self.canvas.bind('<Button-1>', self.onPress)
+						self.canvas.bind('<ButtonRelease-1>', self.onRelease)
+						running = False
+
+
+	#	Set the device to configure
+	#	name: Device name
+	def setDevice(self, name):
+		self.device_name = name
+		self.canvas.itemconfig(self.device_text, text=name)
+		#TODO: Do we need to set ctm here?
+		props = self.xinput('--list-props', name)
+		ctm_start = props.find('Coordinate Transformation Matrix')
+		ctm_end = props.find("\n", ctm_start)
+		if ctm_start < 0 or ctm_end < 0:
+			return
+		ctm_start += 40
+		node_start = props.find('Device Node')
+		node_start = props.find('"', node_start)
+		node_end = props.find('"', node_start + 1)
+		if node_start < 0 or node_end < 0:
+			return
+		self.ctm = [float(x) for x in props[ctm_start:ctm_end].split(', ')]
+		
 	
-	#	Handle touch event
+	#	Handle touch press event
 	#	event: Event including x,y coordinates
 	def onPress(self, event):
-		self.countdown = self.timeout # Reset countdown timer when screen touched
-		if not self.device_name:
-			self.index = 0
-			self.detectTouchscreens()
-			for device in self.devices:
-				# Reset all calibration to increase chance of first press triggering and identifying the device
-				self.setCalibration(device, self.identify_matrix)
+		self.canvas.itemconfig("crosshairs_lines", fill="red")
+		self.canvas.itemconfig("crosshairs_circles", outline="red")
+		self.pressed = True
 
-	
+
 	#	Handle touch release event
 	#	event: Event including x,y coordinates
 	def onRelease(self, event):
-		self.countdown = self.timeout # Reset countdown timer when screen touched
+		self.canvas.itemconfig("crosshairs_lines", fill="white")
+		self.canvas.itemconfig("crosshairs_circles", outline="white")
+		self.pressed = False
 		if not self.device_name:
-			for device in self.devices:
-				last_touch = self.getLastTouch(device)
-				if last_touch.x != 0 or last_touch.y != 0:
-					self.device_name = device
-				else:
-					self.setCalibration(device, self.devices[device]["ctm"]) # Reset calibration of other devices that we changed during detection
-			if self.device_name:
-				self.canvas.itemconfig(self.device_text, text=self.device_name)
-			else:
 				return
 		if self.index < 2:
-			if self.index > 0:
-				# Debounce
-				if abs(event.x - self.touch_points[self.index - 1].x) < self.debounce and abs(event.y - self.touch_points[self.index - 1].y) < self.debounce:
-					return
 			# More points to acquire
 			self.touch_points[self.index].x = event.x
 			self.touch_points[self.index].y = event.y
 			self.index += 1
 		if self.index > 1:
-			# Get average coords for corners of touch rectangle
-			min_x = self.touch_points[0].x
-			max_x = self.touch_points[1].x
-			min_y = self.touch_points[0].y
-			max_y = self.touch_points[1].y
-			if min_x == max_x or min_y == max_y:
-				return #TODO: Check if this condition causes issue elsewhere
-			# Check for rotation
-			a = self.width * 0.7 / (max_x - min_x)
-			if min_x < max_x:
-				c = (self.width * 0.15 - a * min_x) / self.width
+			# Debounce
+			if abs(self.touch_points[0].x - self.touch_points[1].x) < self.debounce and abs(self.touch_points[0].y - self.touch_points[1].y) < self.debounce:
+				self.index = 0
 			else:
-				c = (self.width * 0.15 - a * min_x) / self.width
-			e = self.height * 0.7 / (max_y - min_y)
-			if min_y < max_y:
-				f = (self.height * 0.15 - e * min_y) / self.height
-			else:
-				f = (self.height * 0.15 - e * min_y) / self.height
-			self.transform_matrix[0] = a
-			self.transform_matrix[2] = c
-			self.transform_matrix[4] = e
-			self.transform_matrix[5] = f
-			self.setCalibration(self.device_name, self.transform_matrix, True)
-			#TODO: Allow user to check calibration
-			self.hide()
-			return
+				min_x = self.touch_points[0].x
+				max_x = self.touch_points[1].x
+				min_y = self.touch_points[0].y
+				max_y = self.touch_points[1].y
+				if min_x == max_x or min_y == max_y:
+					return #TODO: Check if this condition causes issue elsewhere
+				# Check for rotation
+				a = self.width * 0.7 / (max_x - min_x)
+				if min_x < max_x:
+					c = (self.width * 0.15 - a * min_x) / self.width
+				else:
+					c = (self.width * 0.15 - a * min_x) / self.width
+				e = self.height * 0.7 / (max_y - min_y)
+				if min_y < max_y:
+					f = (self.height * 0.15 - e * min_y) / self.height
+				else:
+					f = (self.height * 0.15 - e * min_y) / self.height
+				self.setCalibration(self.device_name, [a, 0, c, 0, e, f, 0, 0, 1], True)
+				#TODO: Allow user to check calibration
+				self.hide()
+				return
 		self.drawCross()
 
 	
-	#	Draws the crosshairs for touch registration for current index (0..3)
+	#	Draws the crosshairs for touch registration for current index (0..1)
 	def drawCross(self):
 		if self.index > 1:
 			return
@@ -210,79 +244,6 @@ class zynthian_gui_touchscreen_calibration:
 			self.display_points[self.index].x - self.crosshair_size * 0.2, self.display_points[self.index].y - self.crosshair_size * 0.2,
 			self.display_points[self.index].x + self.crosshair_size * 0.2, self.display_points[self.index].y + self.crosshair_size * 0.2)
 		self.canvas.itemconfig("crosshairs", state=tkinter.NORMAL)
-
-
-	#	Get last touch coordinates from device
-	#	Returns point object with last touch coordinates
-	def getLastTouch(self, device):
-		try:
-			result = run(["xinput", "--query-state", device], stdout=PIPE).stdout.decode()
-			a = result.find("valuator[0]")
-			b = result.find("\n", a)
-			x = int(result[a+12:b])
-			a = result.find("valuator[1]")
-			b = result.find("\n", a)
-			y = int(result[a+12:b])
-		except:
-			logging.warning("Failed to detect touchscreen last touch")
-			return point(0,0)
-		return point(x,y)
-
-
-	#	Populate list of touchscreens with relevant properties
-	def detectTouchscreens(self):
-		self.devices = {}
-		result = run(["xinput", "--list", "--name-only"], stdout=PIPE).stdout.decode().split("\n")
-		# Get properties and check for calibration option
-		for device in result:
-			if device == "":
-				continue
-			properties = run(["xinput", "--list", "--long", device], stdout=PIPE).stdout.decode()
-			if properties.find("master pointer") > 0:
-				continue; # Don't want the master device
-			if properties.find("Type: XITouchClass") > 0:
-				config = {}
-				status = run(["xinput", "--query-state", device], stdout=PIPE).stdout.decode()
-				a = properties.find("Abs MT Position X")
-				b = properties.find("Range:", a)
-				c = properties.find("\n",b)
-				d = properties[b+7:c]
-				e = d.split(" - ")
-				min_x = float(e[0])
-				max_x = float(e[1])
-				a = properties.find("Abs MT Position Y")
-				b = properties.find("Range:", a)
-				c = properties.find("\n",b)
-				d = properties[b+7:c]
-				e = d.split(" - ")
-				min_y = float(e[0])
-				max_y = float(e[1])
-				config["min"] = point(min_x,min_y)
-				config["max"] = point(max_x,max_y)
-				config["ctm"] = self.getMatrix(device)
-				self.devices[device] = config
-
-
-	#	Get the current calibration settings for a device
-	#	device: Name or ID of device
-	#	Returns: Coordinate Transformation Matrix or None on error
-	def getMatrix(self, device):
-		result = run(["xinput", "--list-props", device], stdout=PIPE).stdout.decode()
-		a = result.find("Coordinate Transformation Matrix")
-		b = result.find(":", a)
-		c = result.find("\n", b)
-		if not (b > a and c > b):
-			return None
-		str_matrix = result[b+2:c].split(",")
-		if len(str_matrix) != 9:
-			return None
-		matrix = []
-		try:
-			for value in str_matrix:
-				matrix.append(float(value))
-		except:
-			return None
-		return matrix
 
 
 	#	Apply screen calibration
@@ -302,8 +263,8 @@ class zynthian_gui_touchscreen_calibration:
 				matrix[6],
 				matrix[7],
 				matrix[8])
-			proc = run(["xinput", "--set-prop", device, "Coordinate Transformation Matrix",
-				str(matrix[0]), str(matrix[1]), str(matrix[2]), str(matrix[3]), str(matrix[4]), str(matrix[5]), str(matrix[6]), str(matrix[7]), str(matrix[8])])
+			self.xinput("--set-prop", device, "Coordinate Transformation Matrix",
+				str(matrix[0]), str(matrix[1]), str(matrix[2]), str(matrix[3]), str(matrix[4]), str(matrix[5]), str(matrix[6]), str(matrix[7]), str(matrix[8]))
 			if write_file:
 				# Update config file
 				try:
@@ -358,6 +319,8 @@ class zynthian_gui_touchscreen_calibration:
 			self.drawCross()
 			self.main_frame.grid()
 			self.onTimer()
+			self.detect_thread = Thread(target=self.detectDevice, args=(), daemon=True)
+			self.detect_thread.start()
 
 
 	#	Handle one second timer trigger
@@ -366,13 +329,11 @@ class zynthian_gui_touchscreen_calibration:
 			self.canvas.itemconfig(self.countdown_text, text="Closing in %ds" % (self.countdown))
 			if self.countdown <= 0:
 				self.hide()
-				if self.device_name:
-					# Timeout so restore previous config
-					self.setCalibration(self.device_name, self.devices[self.device_name]["ctm"])
-			else:
-				self.timer = Timer(interval=1, function=self.onTimer)
-				self.timer.start()
+				return
+			if not self.pressed:
 				self.countdown -= 1
+			self.timer = Timer(interval=1, function=self.onTimer)
+			self.timer.start()
 
 
 	#	Handle zyncoder read - called by parent when zyncoders updated

--- a/zyngui/zynthian_gui_touchscreen_calibration.py
+++ b/zyngui/zynthian_gui_touchscreen_calibration.py
@@ -1,0 +1,284 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#******************************************************************************
+# ZYNTHIAN PROJECT: Zynthian GUI
+# 
+# Zynthian GUI Touchscreen Calibration Class
+# 
+# Copyright (C) 2020 Brian Walton <brian@riban.co.uk>
+#
+#******************************************************************************
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of
+# the License, or any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# For a full copy of the GNU General Public License see the LICENSE.txt file.
+# 
+#******************************************************************************
+
+import tkinter
+import logging
+import tkinter.font as tkFont
+from PIL import Image, ImageTk
+from threading import Timer
+from subprocess import run,PIPE
+
+# Zynthian specific modules
+from . import zynthian_gui_config
+
+import time
+
+# Little class to represent x,y coordinates
+class point:
+	x = 0.0
+	y = 0.0
+	def __init__(self, x=0, y=0):
+		self.x = x
+		self.y = y
+
+#------------------------------------------------------------------------------
+# Zynthian Touchscreen Calibration GUI Class
+#------------------------------------------------------------------------------
+
+
+# Class implements zynthian touchscreen calibration
+class zynthian_gui_touchscreen_calibration:
+
+	# Function to initialise class
+	def __init__(self):
+		self.shown=False
+		self.zyngui=zynthian_gui_config.zyngui
+		self.height = zynthian_gui_config.display_height
+		self.width = zynthian_gui_config.display_width
+
+		# Main Frame
+		self.main_frame = tkinter.Frame(zynthian_gui_config.top,
+			width = self.width,
+			height = self.height,
+			bg = zynthian_gui_config.color_bg)
+
+		# Canvas
+		self.canvas = tkinter.Canvas(self.main_frame,
+			height = self.height,
+			width = self.width,
+			bg="black",
+			bd=0,
+			highlightthickness=0)
+		self.canvas.bind('<ButtonRelease-1>', self.onRelease)
+		
+		# Instruction text
+		self.instruction_text = self.canvas.create_text(self.width / 2,
+			self.height / 2 - zynthian_gui_config.font_size * 2,
+			font=(zynthian_gui_config.font_family,zynthian_gui_config.font_size,"normal"),
+			fill="white",
+			text="Touch each cross as it appears")
+
+		# Countdown timer
+		self.countdown_text = self.canvas.create_text(self.width / 2,
+			self.height / 2,
+			font=(zynthian_gui_config.font_family,zynthian_gui_config.font_size,"normal"),
+			fill="red",
+			text="Closing in 5s")
+		self.timer = Timer(interval=1, function=self.onTimer)
+		
+		# Coordinate transform matrix
+		self.transform_matrix = [1,0,0, 0,1,0, 0,0,1]
+		self.identify_matrix = [1,0,0, 0,1,0, 0,0,1]
+		self.display_points = [point(self.width * 0.15, self.height * 0.15), point(self.width * 0.5, self.height * 0.85), point(self.width * 0.85, self.height * 0.5)]
+		self.touch_points = [point(), point(), point()]
+		self.touch_min = point()
+		self.touch_max = point()
+
+		# Crosshair
+		self.index = 0 # Index of current calibration point (0=NE, 1=S, 2=E)
+		self.crosshair_size = self.width / 20 # half width of cross hairs
+		self.crosshair_vertical = self.canvas.create_line(
+			self.display_points[self.index].x, self.display_points[self.index].y - self.crosshair_size,
+			self.display_points[self.index].x, self.display_points[self.index].y - self.crosshair_size,
+			fill="white")
+		self.crosshair_horizontal = self.canvas.create_line(
+			self.display_points[self.index].x - self.crosshair_size, self.display_points[self.index].y,
+			self.display_points[self.index].x + self.crosshair_size, self.display_points[self.index].y,
+			fill="white")
+		#TODO: Add circle to crosshairs?
+
+		self.canvas.pack()
+		self.device_name = None
+
+	
+	#	Handle touch release event
+	#	event: Event including x,y coordinates
+	def onRelease(self, event):
+		self.countdown = 5 # Reset countdown timer when screen touched
+		if(self.index < 3):
+			self.touch_points[self.index].x = event.x
+			self.touch_points[self.index].y = event.y
+		self.index += 1
+		if self.index > 2:
+			if self.calcCalibrationMatrix():
+				self.setCalibration(self.transform_matrix, True)
+			#TODO: Allow user to check calibration
+			self.hide()
+		self.drawCross()
+
+	
+	#	Draws the crosshairs for touch registration for current index (0..2)
+	def drawCross(self):
+		if self.index > 2:
+			return
+		self.canvas.coords(self.crosshair_vertical,
+			self.display_points[self.index].x, self.display_points[self.index].y - self.crosshair_size,
+			self.display_points[self.index].x, self.display_points[self.index].y + self.crosshair_size)
+		self.canvas.coords(self.crosshair_horizontal,
+			self.display_points[self.index].x - self.crosshair_size, self.display_points[self.index].y,
+			self.display_points[self.index].x + self.crosshair_size, self.display_points[self.index].y)
+
+
+	#	Get the name and parameters for the first touchscreen detected
+	#	TODO: Allow configuration of other touchscreens, not just first
+	def getFirstTouchscreen(self):
+		self.device_name = None
+		result = run(["xinput", "--list", "--name-only"], stdout=PIPE).stdout.decode().split("\n")
+		# Get properties and check for calibration option
+		try:
+			for device in result:
+				if device == "":
+					continue
+				properties = run(["xinput", "--list", "--long", device], stdout=PIPE).stdout.decode()
+				if properties.find("master pointer") > 0:
+					continue; # Don't want the master device
+				if properties.find("Type: XITouchClass") > 0:
+					a = properties.find("Abs MT Position X")
+					b = properties.find("Range:", a)
+					c = properties.find("\n",b)
+					d = properties[b+7:c]
+					e = d.split(" - ")
+					self.touch_min.x = float(e[0])
+					self.touch_max.x = float(e[1])
+					a = properties.find("Abs MT Position Y")
+					b = properties.find("Range:", a)
+					c = properties.find("\n",b)
+					d = properties[b+7:c]
+					e = d.split(" - ")
+					self.touch_min.y = float(e[0])
+					self.touch_max.y = float(e[1])
+					self.device_name = device
+		except Exception as e:
+			logging.warning("Failed to find touchscreen for calibration", e)
+
+
+	# 	Calculate calibration matrix from previously populated display and touch points
+	#	Returns: True on success
+	def calcCalibrationMatrix(self):
+		Divider = (((self.touch_points[0].x - self.touch_points[2].x) * (self.touch_points[1].y - self.touch_points[2].y)) -
+			((self.touch_points[1].x - self.touch_points[2].x) * (self.touch_points[0].y - self.touch_points[2].y)))
+		if Divider == 0:
+			return False
+		self.transform_matrix[0] = (((self.display_points[0].x - self.display_points[2].x) * (self.touch_points[1].y - self.touch_points[2].y)) - 
+			((self.display_points[1].x - self.display_points[2].x) * (self.touch_points[0].y - self.touch_points[2].y)))
+		self.transform_matrix[1] = (((self.touch_points[0].x - self.touch_points[2].x) * (self.display_points[1].x - self.display_points[2].x)) - 
+			((self.display_points[0].x - self.display_points[2].x) * (self.touch_points[1].x - self.touch_points[2].x)))
+		self.transform_matrix[2] = ((self.touch_points[2].x * self.display_points[1].x - self.touch_points[1].x * self.display_points[2].x) * self.touch_points[0].y +
+			(self.touch_points[0].x * self.display_points[2].x - self.touch_points[2].x * self.display_points[0].x) * self.touch_points[1].y +
+			(self.touch_points[1].x * self.display_points[0].x - self.touch_points[0].x * self.display_points[1].x) * self.touch_points[2].y)
+		self.transform_matrix[3] = (((self.display_points[0].y - self.display_points[2].y) * (self.touch_points[1].y - self.touch_points[2].y)) - 
+			((self.display_points[1].y - self.display_points[2].y) * (self.touch_points[0].y - self.touch_points[2].y)))
+		self.transform_matrix[4] = (((self.touch_points[0].x - self.touch_points[2].x) * (self.display_points[1].y - self.display_points[2].y)) - 
+			((self.display_points[0].y - self.display_points[2].y) * (self.touch_points[1].x - self.touch_points[2].x)))
+		self.transform_matrix[5] = ((self.touch_points[2].x * self.display_points[1].y - self.touch_points[1].x * self.display_points[2].y) * self.touch_points[0].y +
+			(self.touch_points[0].x * self.display_points[2].y - self.touch_points[2].x * self.display_points[0].y) * self.touch_points[1].y +
+			(self.touch_points[1].x * self.display_points[0].y - self.touch_points[0].x * self.display_points[1].y) * self.touch_points[2].y)
+		return True
+
+
+	#	Apply screen calibration
+	#	matrix: Transorm matrix as 9 element array (3x3)
+	#	write_file: True to write configuration to file (default: false)
+	def setCalibration(self, matrix, write_file=False):
+		try:
+			proc = run(["xinput", "--set-prop", self.device_name, "Coordinate Transformation Matrix",
+				str(matrix[0]), str(matrix[1]), str(matrix[2]), str(matrix[3]), str(matrix[4]), str(matrix[5]), "0", "0", "1"])
+			#logging.debug("***setCalibration: ", proc.args)
+			if write_file:
+				# Create config file
+				f = open("/etc/X11/xorg.conf.d/99-calibration.conf", "w")
+				f.write('Section "InputClass"\n')
+				f.write('	Identifier "calibration"\n')
+				f.write('	MatchProduct "%s"\n'%(self.device_name))
+				f.write('	Option "TransformationMatrix" "%f %f %f %f %f %f 0 0 1"\n' % (matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5]))
+				f.write('EndSection\n')
+				f.close()
+		except Exception as e:
+			logging.warning("Failed to set touchscreen calibration", e)
+	
+
+	#	Hide display
+	def hide(self):
+		if self.shown:
+			self.shown=False
+			self.timer.cancel()
+			self.main_frame.grid_forget()
+			self.zyngui.show_screen(self.zyngui.active_screen)
+
+
+	# 	Show display
+	def show(self):
+		if not self.shown:
+			self.shown=True
+			self.canvas.itemconfig(self.countdown_text, text="Closing in 5s")
+			self.countdown= 5
+			self.getFirstTouchscreen()
+			if not self.device_name:
+				logging.warning("No touchscreen detected")
+				self.hide() #TODO: This does not close screen
+				return
+			self.setCalibration(self.identify_matrix) # Clear calibration
+			self.index = 0
+			self.drawCross()
+			self.main_frame.grid()
+			self.onTimer()
+
+
+	#	Handle one second timer trigger
+	def onTimer(self):
+		if self.shown:
+			self.canvas.itemconfig(self.countdown_text, text="Closing in %ds" % (self.countdown))
+			if self.countdown <= 0:
+				self.hide()
+			else:
+				self.timer = Timer(interval=1, function=self.onTimer)
+				self.timer.start()
+				self.countdown -= 1
+
+
+	#	Handle zyncoder read - called by parent when zyncoders updated
+	def zyncoder_read(self):
+		pass
+
+
+	#	Handle refresh loading - called by parent during screen load
+	def refresh_loading(self):
+		pass
+
+	
+	#	Handle physical switch press
+	#	type: Switch duration type (default: short)
+	def switch_select(self, type='S'):
+		pass
+
+
+	#	Handle BACK button action
+	def back_action(self):
+		self.hide()
+		return self.zyngui.active_screen
+
+
+
+#-------------------------------------------------------------------------------

--- a/zyngui/zynthian_gui_touchscreen_calibration.py
+++ b/zyngui/zynthian_gui_touchscreen_calibration.py
@@ -301,6 +301,7 @@ class zynthian_gui_touchscreen_calibration:
 				str(matrix[0]), str(matrix[1]), str(matrix[2]), str(matrix[3]), str(matrix[4]), str(matrix[5]), str(matrix[6]), str(matrix[7]), str(matrix[8]))
 			if write_file:
 				# Update exsting config in file
+				"""
 				try:
 					f = open("/etc/X11/xorg.conf.d/99-calibration.conf", "r")
 					config = f.read()
@@ -319,17 +320,27 @@ class zynthian_gui_touchscreen_calibration:
 								f.close()
 								return
 						section_start = config.find('Section "InputClass"', section_end)
-						
 				except:
 					pass # File probably does not yet exist
+				"""
 				# If we got here then we need to append this device to config
-				f = open("/etc/X11/xorg.conf.d/99-calibration.conf", "a")
-				f.write('\nSection "InputClass" # Created %s\n'%(datetime.now()))
-				f.write('	Identifier "calibration"\n')
-				f.write('	MatchProduct "%s"\n'%(device))
-				f.write('	Option "TransformationMatrix" "%f %f %f %f %f %f %f %f %f"\n' % (matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5], matrix[6], matrix[7], matrix[8]))
-				f.write('EndSection\n')
-				f.close()
+				# For the record it is with deep reservation that I code this duplicate writing of files - I was only follwing orders!
+				try:
+					os.mkdir(os.environ.get("ZYNTHIAN_CONFIG_DIR") + "/touchscreen/")
+				except:
+					pass # directory already exists
+				with open(os.environ.get("ZYNTHIAN_CONFIG_DIR") + "/touchscreen/" + os.environ.get("DISPLAY_NAME"), "w") as f:
+					f.write('Section "InputClass" # Created %s\n'%(datetime.now()))
+					f.write('	Identifier "calibration"\n')
+					f.write('	MatchProduct "%s"\n'%(device))
+					f.write('	Option "TransformationMatrix" "%f %f %f %f %f %f %f %f %f"\n' % (matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5], matrix[6], matrix[7], matrix[8]))
+					f.write('EndSection\n')
+				with open("/etc/X11/xorg.conf.d/99-calibration.conf", "w") as f:
+					f.write('Section "InputClass" # Created %s\n'%(datetime.now()))
+					f.write('	Identifier "calibration"\n')
+					f.write('	MatchProduct "%s"\n'%(device))
+					f.write('	Option "TransformationMatrix" "%f %f %f %f %f %f %f %f %f"\n' % (matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5], matrix[6], matrix[7], matrix[8]))
+					f.write('EndSection\n')
 		except Exception as e:
 			logging.warning("Failed to set touchscreen calibration", e)
 

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -78,6 +78,7 @@ from zyngui.zynthian_gui_audio_recorder import zynthian_gui_audio_recorder
 from zyngui.zynthian_gui_midi_recorder import zynthian_gui_midi_recorder
 #from zyngui.zynthian_gui_autoeq import zynthian_gui_autoeq
 from zyngui.zynthian_gui_stepsequencer import zynthian_gui_stepsequencer
+from zyngui.zynthian_gui_touchscreen_calibration import zynthian_gui_touchscreen_calibration
 
 #from zyngui.zynthian_gui_control_osc_browser import zynthian_gui_osc_browser
 
@@ -327,6 +328,7 @@ class zynthian_gui:
 		self.screens['zs3_options'] = zynthian_gui_zs3_options()
 		self.screens['main'] = zynthian_gui_main()
 		self.screens['admin'] = zynthian_gui_admin()
+		self.screens['touchscreen_clibration'] = zynthian_gui_touchscreen_calibration()
 
 		# Create UI Apps Screens
 		self.screens['alsa_mixer'] = self.screens['control']
@@ -487,6 +489,10 @@ class zynthian_gui:
 	def hide_info(self):
 		self.screens['info'].hide()
 		self.show_screen()
+
+
+	def calibrate_touchscreen(self):
+		self.show_modal('touchscreen_clibration')
 
 
 	def load_snapshot(self):


### PR DESCRIPTION
This now works as requested.

- Screen shows target crosshairs that must be touched and released
- First target does no calibration and only detects the touch interface
- Display type shown after first touch
- Consequent touches are measured on release, allowing drag to target for more accuracy
- After second touch the calibration is written to two files (I disagree!)
- Each target appears white and changes to red when screen touched
- Touches too close together are ignored (half a screen)
- A timeout of 15s after last touch or release will close screen without saving configuration
- BACK button will close screen without saving configuration