### PR TITLE
VNC setting on admin menu

### DIFF
--- a/zynconf/zynthian_config.py
+++ b/zynconf/zynthian_config.py
@@ -482,6 +482,18 @@ def is_service_active(service):
 		return True
 	else:
 		return False
+		
+def is_service_enabled(service):
+	cmd="systemctl is-enabled %s" % service
+	try:
+		result=check_output(cmd, shell=True).decode('utf-8','ignore')
+	except Exception as e:
+		result="ERROR: %s" % e
+	#loggin.debug("Is service "+str(service)+" enabled? => "+str(result))
+	if result.strip()=='enabled':
+		return True
+	else:
+		return False
 
 #------------------------------------------------------------------------------
 # Jackd configuration
@@ -499,4 +511,45 @@ def get_jackd_options():
 	return jackd_options
 
 #------------------------------------------------------------------------------
+# VNC service controls
+#------------------------------------------------------------------------------
 
+def start_vnc():
+	logging.info("STARTING VNC")
+	cmd = "systemctl start vncserver-x11-serviced && systemctl enable vncserver-x11-serviced"
+
+	check_output(cmd, shell=True)
+	sleep(2)
+
+	counter=0
+	success=False
+	while not success:
+		counter += 1
+		if ( is_service_active("vncserver-x11-serviced") and is_service_enabled("vncserver-x11-serviced")):
+			succes=True
+			return True
+
+		elif counter>20:
+			return False
+
+		sleep(1)
+		
+def stop_vnc():
+	logging.info("Stopping VNC")
+	cmd = "systemctl stop vncserver-x11-serviced && systemctl disable vncserver-x11-serviced"
+
+	check_output(cmd, shell=True)
+	sleep(2)
+
+	counter=0
+	success=False
+	while not success:
+		counter += 1
+		if not( is_service_active("vncserver-x11-serviced") or is_service_enabled("vncserver-x11-serviced")):
+			succes=True
+			return True
+
+		elif counter>20:
+			return False
+
+		sleep(1)

--- a/zynconf/zynthian_config.py
+++ b/zynconf/zynthian_config.py
@@ -525,8 +525,8 @@ def start_vnc():
 	success=False
 	while not success:
 		counter += 1
-		if ( is_service_active("vncserver-x11-serviced") and is_service_enabled("vncserver-x11-serviced")):
-			succes=True
+		if is_service_active("vncserver-x11-serviced") and is_service_enabled("vncserver-x11-serviced"):
+			success=True
 			return True
 
 		elif counter>20:
@@ -544,9 +544,10 @@ def stop_vnc():
 	counter=0
 	success=False
 	while not success:
+		
 		counter += 1
-		if not( is_service_active("vncserver-x11-serviced") or is_service_enabled("vncserver-x11-serviced")):
-			succes=True
+		if not (is_service_active("vncserver-x11-serviced") or is_service_enabled("vncserver-x11-serviced")):
+			success=True
 			return True
 
 		elif counter>20:

--- a/zyngui/zynthian_gui_admin.py
+++ b/zyngui/zynthian_gui_admin.py
@@ -136,7 +136,12 @@ class zynthian_gui_admin(zynthian_gui_selector):
 		else:
 			self.list_data.append((self.start_wifi,0,"[  ] Wi-Fi"))
 			self.list_data.append((self.start_wifi_hotspot,0,"[  ] Wi-Fi Hotspot"))
-
+			
+		if zynconf.is_service_active("vncserver-x11-serviced"):
+			self.list_data.append((self.stop_vnc,0,"[x] VNC enabled"))
+		else:
+			elf.list_data.append((self.start_vnc,0,"[  ] VNC Disabled")) 
+			
 		self.list_data.append((None,0,"-----------------------------"))
 		self.list_data.append((self.test_audio,0,"Test Audio"))
 		self.list_data.append((self.test_midi,0,"Test MIDI"))
@@ -680,6 +685,22 @@ class zynthian_gui_admin(zynthian_gui_selector):
 		if not zynconf.stop_wifi():
 			self.zyngui.show_info("STOPPING WIFI ERROR\n")
 			self.zyngui.add_info("Can't stop WIFI network!","WARNING")
+			self.zyngui.hide_info_timer(2000)
+
+		self.fill_list()
+		
+	def start_vnc(self):
+		if not zynconf.start_vnc():
+			self.zyngui.show_info("STARTING VNC ERROR\n")
+			self.zyngui.add_info("Can't start VNC Service!","WARNING")
+			self.zyngui.hide_info_timer(2000)
+
+		self.fill_list()
+		
+	def stop_vnc(self):
+		if not zynconf.stop_vnc():
+			self.zyngui.show_info("STOPPING VNC ERROR\n")
+			self.zyngui.add_info("Can't stop VNC Service!","WARNING")
 			self.zyngui.hide_info_timer(2000)
 
 		self.fill_list()

--- a/zyngui/zynthian_gui_admin.py
+++ b/zyngui/zynthian_gui_admin.py
@@ -140,7 +140,7 @@ class zynthian_gui_admin(zynthian_gui_selector):
 		if zynconf.is_service_active("vncserver-x11-serviced"):
 			self.list_data.append((self.stop_vnc,0,"[x] VNC enabled"))
 		else:
-			elf.list_data.append((self.start_vnc,0,"[  ] VNC Disabled")) 
+			self.list_data.append((self.start_vnc,0,"[  ] VNC Disabled")) 
 			
 		self.list_data.append((None,0,"-----------------------------"))
 		self.list_data.append((self.test_audio,0,"Test Audio"))


### PR DESCRIPTION
As i explained in the forums, I want to develop some things for zynthian and this is kind of a PoC.

Disabling VNC proves advantageous as [it can be considered a security risk](https://security.stackexchange.com/questions/124958/how-do-i-assess-and-mitigate-the-security-risks-of-a-vnc-tool), since misconfiguration might lead to an increased attack surface. 

This merge introduces a menu option in the admin menu to enable/disable the VNC service (just runs systemctl start and enable and stop and disable for the services and checks for the service status).

I don’t know if maybe this is more useful if i add an install VNC option first if the service is not installed, i was just trying to get acquainted with how the menu system works.

This does persist between reboots but it does so by using systemd.