### PR TITLE
Fixes failure to calibrate screen if ambiguous devices connected

### DIFF
--- a/zyngui/zynthian_gui_touchscreen_calibration.py
+++ b/zyngui/zynthian_gui_touchscreen_calibration.py
@@ -130,9 +130,12 @@ class zynthian_gui_touchscreen_calibration:
 	#	Returns: Output of xinput as string
 	#	Credit: https://github.com/reinderien/xcalibrate
 	def xinput(self, *args):
-		return run(args=('/usr/bin/xinput', *args),
-			stdout=PIPE, check=True,
-			universal_newlines=True).stdout
+		try:
+			return run(args=('/usr/bin/xinput', *args),
+				stdout=PIPE, check=True,
+				universal_newlines=True).stdout
+		except:
+			return ""
 
 
 	#	Thread waiting for first touch to detect touch interface


### PR DESCRIPTION
I have added exception handling to the xinput function to allow the calibration to complete or fail gracefully if an error occurs. A user found that their multifunction keyboard / touchpad was triggering xinput to fail due to abmiguity of the device names. This fix allows calibration to complete.