### PR TITLE
Fixes engines failing to start or show UI when toggling VNC

### DIFF
--- a/zyngine/zynthian_engine.py
+++ b/zyngine/zynthian_engine.py
@@ -62,7 +62,6 @@ class zynthian_basic_engine:
 		self.proc_timeout = 20
 		self.proc_start_sleep = None
 		self.command = command
-		self.command_env = None
 		self.command_prompt = prompt
 
 
@@ -78,12 +77,8 @@ class zynthian_basic_engine:
 		if not self.proc:
 			logging.info("Starting Engine {}".format(self.name))
 			try:
-
 				logging.debug("Command: {}".format(self.command))
-				if self.command_env:
-					self.proc=pexpect.spawn(self.command, timeout=self.proc_timeout, env=self.command_env)
-				else:
-					self.proc=pexpect.spawn(self.command, timeout=self.proc_timeout)
+				self.proc=pexpect.spawn(self.command, timeout=self.proc_timeout)
 
 				self.proc.delaybeforesend = 0
 
@@ -208,28 +203,13 @@ class zynthian_engine(zynthian_basic_engine):
 
 
 	def config_remote_display(self):
-		fvars={}
-		if os.environ.get('ZYNTHIANX'):
-			fvars['DISPLAY']=os.environ.get('ZYNTHIANX')
-		else:
-			try:
-				with open("/root/.remote_display_env","r") as fh:
-					lines = fh.readlines()
-					for line in lines:
-						parts=line.strip().split('=')
-						if len(parts)>=2 and parts[1]: fvars[parts[0]]=parts[1]
-			except:
-				fvars['DISPLAY']=""
-
-		if 'DISPLAY' not in fvars or not fvars['DISPLAY'] or fvars['DISPLAY'] == 'NONE':
-			logging.info("NO REMOTE DISPLAY")
-			return False
-		else:
-			logging.info("REMOTE DISPLAY: %s" % fvars['DISPLAY'])
-			self.command_env=os.environ.copy()
-			for f,v in fvars.items():
-				self.command_env[f]=v
+		if 'ZYNTHIAN_X11_SSH' in os.environ and 'SSH_CLIENT' in os.environ and 'DISPLAY' in os.environ:
 			return True
+		if os.system('systemctl -q is-active vncserver@\:1'):
+			return False
+		os.environ['DISPLAY'] = ':1'
+		return True
+
 
 	# ---------------------------------------------------------------------------
 	# Loading GUI signalization

--- a/zyngine/zynthian_engine.py
+++ b/zyngine/zynthian_engine.py
@@ -62,7 +62,7 @@ class zynthian_basic_engine:
 		self.proc_timeout = 20
 		self.proc_start_sleep = None
 		self.command = command
-		self.command_env = None
+		self.command_env = os.environ.copy()
 		self.command_prompt = prompt
 
 
@@ -79,7 +79,7 @@ class zynthian_basic_engine:
 			logging.info("Starting Engine {}".format(self.name))
 			try:
 				logging.debug("Command: {}".format(self.command))
-				self.proc=pexpect.spawn(self.command, timeout=self.proc_timeout)
+				self.proc=pexpect.spawn(self.command, timeout=self.proc_timeout, env=self.command_env)
 
 				self.proc.delaybeforesend = 0
 

--- a/zyngine/zynthian_engine_jalv.py
+++ b/zyngine/zynthian_engine_jalv.py
@@ -67,6 +67,15 @@ class zynthian_engine_jalv(zynthian_engine):
 		("Raffo MiniMoog", {'TYPE': "MIDI Synth",'URL': "http://example.org/raffo"})
 	])
 
+	broken_ui = [
+			'http://calf.sourceforge.net/plugins/Monosynth',
+			'http://calf.sourceforge.net/plugins/Organ',
+			'http://nickbailey.co.nr/triceratops',
+			'http://code.google.com/p/amsynth/amsynth'
+		]
+	if "Raspberry Pi 4" not in os.environ.get('RBPI_VERSION'):
+		broken_ui.append('http://tytel.org/helm')
+
 	#------------------------------------------------------------------------------
 	# Native formats configuration (used by zynapi_install, preset converter, etc.)
 	#------------------------------------------------------------------------------
@@ -162,17 +171,9 @@ class zynthian_engine_jalv(zynthian_engine):
 		self.nickname = "JV/" + plugin_name
 		self.plugin_name = plugin_name
 		self.plugin_url = self.plugins_dict[plugin_name]['URL']
-		broken_ui = [
-				'http://calf.sourceforge.net/plugins/Monosynth',
-				'http://calf.sourceforge.net/plugins/Organ',
-				'http://nickbailey.co.nr/triceratops',
-				'http://code.google.com/p/amsynth/amsynth'
-			]
-		if "Raspberry Pi 4" not in check_output(["cat", "/proc/device-tree/model"]).decode():
-			broken_ui.append('http://tytel.org/helm')
-		if self.plugin_url in broken_ui:
-			self.ui = False
-		else:
+
+		self.ui = False
+		if self.plugin_url not in self.broken_ui and 'UI' in self.plugins_dict[plugin_name]:
 			self.ui = self.plugins_dict[plugin_name]['UI']
 
 		if plugin_type=="MIDI Tool":

--- a/zyngine/zynthian_engine_jalv.py
+++ b/zyngine/zynthian_engine_jalv.py
@@ -162,6 +162,18 @@ class zynthian_engine_jalv(zynthian_engine):
 		self.nickname = "JV/" + plugin_name
 		self.plugin_name = plugin_name
 		self.plugin_url = self.plugins_dict[plugin_name]['URL']
+		broken_ui = [
+				'http://calf.sourceforge.net/plugins/Monosynth',
+				'http://calf.sourceforge.net/plugins/Organ',
+				'http://nickbailey.co.nr/triceratops',
+				'http://code.google.com/p/amsynth/amsynth'
+			]
+		if "Raspberry Pi 4" not in check_output(["cat", "/proc/device-tree/model"]).decode():
+			broken_ui.append('http://tytel.org/helm')
+		if self.plugin_url in broken_ui:
+			self.ui = False
+		else:
+			self.ui = self.plugins_dict[plugin_name]['UI']
 
 		if plugin_type=="MIDI Tool":
 			self.options['midi_route'] = True
@@ -171,7 +183,7 @@ class zynthian_engine_jalv(zynthian_engine):
 			self.options['note_range'] = False
 
 		if not dryrun:
-			if self.config_remote_display():
+			if self.config_remote_display() and self.ui:
 				self.command = ("jalv.gtk --jack-name {} {}".format(self.get_jalv_jackname(), self.plugin_url))
 			else:
 				self.command = ("jalv -n {} {}".format(self.get_jalv_jackname(), self.plugin_url))
@@ -271,6 +283,8 @@ class zynthian_engine_jalv(zynthian_engine):
 
 
 	def set_preset(self, layer, preset, preload=False):
+		if not preset[0]:
+			return
 		output=self.proc_cmd("preset {}".format(preset[0]))
 
 		#Parse new controller values

--- a/zyngine/zynthian_lv2.py
+++ b/zyngine/zynthian_lv2.py
@@ -31,6 +31,7 @@ import string
 import logging
 import contextlib
 import re
+import urllib.parse
 
 from enum import Enum
 from collections import OrderedDict
@@ -116,6 +117,18 @@ def is_plugin_enabled(plugin_name):
 		return False
 
 
+def	is_plugin_ui(plugin):
+	for uri in plugin.get_data_uris():
+		try:
+			with open(urllib.parse.unquote(str(uri)[7:])) as f:
+				if f.read().find("a ui:X11UI") > 0:
+					return True
+		except:
+			logging.error("Failed to get UI for plugin %s", str(plugin.get_name()))
+			pass
+	return False
+
+
 def generate_plugins_config_file(refresh=True):
 	global world, plugins, plugins_mtime
 	genplugins = OrderedDict()
@@ -132,7 +145,8 @@ def generate_plugins_config_file(refresh=True):
 				'URL': str(plugin.get_uri()),
 				'TYPE': get_plugin_type(plugin).value,
 				'CLASS': re.sub(' Plugin', '', str(plugin.get_class().get_label())),
-				'ENABLED': is_plugin_enabled(name)
+				'ENABLED': is_plugin_enabled(name),
+				'UI': is_plugin_ui(plugin)
 			}
 
 		plugins = OrderedDict(sorted(genplugins.items()))


### PR DESCRIPTION
Fixes #zynthian/zynthian-issue-tracking/issues/407.

- Detects if LV2 has UI during scan for new plugins
- Checks list of broken UIs that don't work on Zynthian
  - Helm only works on RPi4 so checks for that too
- Starts jalv.gtk if VNC server running forwarding display to VNC display
- Starts jalv.gtk if `ZYNTHIAN_X11_SSH` env var set and forwards display to ssh X11 display
- Starts jalv if UI or display not available
- Does not show generic UI if there is not an engine specific UI (many audio effects have generic looking displays defined fro modui)
- Requires user to search for new plugins and presets to benefit from changes

I would prefer to change the name of the vnc service to lose `@\:1` but that is subject of a different request. It will require changes to multiple repositories (and fixing current installations) so deferring for now.

I have tested this on official Zynthian hardware 3 & 4.1 with Raspberry Pi 3 and 4. It seems to operate as expected with many issues resolved. Please test further before merging to _testing_ branch.