### PR TITLE
Fixes #461 - stuck MIDI notes in SMF player.

### DIFF
--- a/zynlibs/zynsmf/event.cpp
+++ b/zynlibs/zynsmf/event.cpp
@@ -128,7 +128,7 @@ Event::Event(uint32_t nTime, uint8_t nType, uint8_t nSubtype, uint32_t nSize, ui
 			case 0x80:
 				DPRINTF("MIDI Note Off Channel:%u Note: %u Velocity: %u\n", nChannel, *(pData), *(pData + 1));
 				// Convert note off to zero velocity note on (used elsewhere, e.g. to silence hanging notes and may offer running status)
-				m_nSubtype = 0x90;
+				m_nSubtype = 0x90 | nChannel;
 				*(m_pData + 1) = 0x00;
 				break;
 			case 0x90:


### PR DESCRIPTION
Was sending note-off for wrong channel.
Conversion of NOTE OFF to NOTE ON with zero velocity ignored channel.