### PR TITLE
Alternative workflow proposal.

### DIFF
--- a/zyngui/zynthian_gui_control.py
+++ b/zyngui/zynthian_gui_control.py
@@ -261,28 +261,31 @@ class zynthian_gui_control(zynthian_gui_selector):
 	def select_action(self, i, t='S'):
 		self.set_mode_control()
 
+	def prev(self):
+		self.index-=1
+		if self.index<0:
+			self.index=0
+		self.select(self.index)
+		self.click_listbox()
+		return True
 
-	def back_action(self):
+	def back_action(self,t='S'):
 		# If in controller map selection, back to instrument control
-		if self.mode=='select':
-			self.set_mode_control()
-			return ''
-
-		# If control xyselect mode active, disable xyselect mode
+		if self.mode=='select':f
 		elif self.xyselect_mode:
 			logging.debug("DISABLE XYSELECT MODE")
 			self.unset_xyselect_mode()
 			return 'control'
-
 		# If in MIDI-learn mode, back to instrument control
 		elif self.zyngui.midi_learn_mode or self.zyngui.midi_learn_zctrl:
 			self.zyngui.exit_midi_learn_mode()
 			return ''
-
-		else:
-			self.zyngui.screens['layer'].restore_curlayer()
-			return None
-
+		elif t=='S':
+			self.prev()
+			return ''
+		elif t=='B':
+			#self.zyngui.screens['layer'].restore_curlayer()
+			return 'preset'
 
 	def next(self):
 		self.index+=1
@@ -291,7 +294,6 @@ class zynthian_gui_control(zynthian_gui_selector):
 		self.select(self.index)
 		self.click_listbox()
 		return True
-
 
 	def switch_select(self, t='S'):
 		if t=='S':
@@ -307,7 +309,6 @@ class zynthian_gui_control(zynthian_gui_selector):
 				self.set_mode_select()
 			elif self.mode=='select':
 				self.click_listbox()
-
 
 	def select(self, index=None):
 		super().select(index)

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -1021,13 +1021,15 @@ class zynthian_gui:
 				self.show_screen('layer')
 
 		elif i==1:
+			screen_back=None
 			if self.modal_screen:
 				logging.debug("CLOSE MODAL => " + self.modal_screen)
-				self.show_screen('main')
+				screen_back = self.screens[self.modal_screen].back_action('B')
+				self.show_screen(screen_back)
 
-			elif self.active_screen=='preset':
+			elif self.active_screen=='control':
 				self.screens['preset'].restore_preset()
-				self.show_screen('control')
+				self.show_screen('preset')
 
 			elif self.active_screen in ['main', 'admin'] and len(self.screens['layer'].layers)>0:
 				self.show_control()
@@ -1093,7 +1095,7 @@ class zynthian_gui:
 
 				# Try to call modal back_action method:
 				try:
-					screen_back = self.screens[self.modal_screen].back_action()
+					screen_back = self.screens[self.modal_screen].back_action('S')
 					logging.debug("SCREEN BACK => " + screen_back)
 				except:
 					pass
@@ -1107,7 +1109,7 @@ class zynthian_gui:
 
 			else:
 				try:
-					screen_back = self.screens[self.active_screen].back_action()
+					screen_back = self.screens[self.active_screen].back_action('S')
 				except:
 					pass
 

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -987,7 +987,7 @@ class zynthian_gui:
 
 		elif i==1:
 			#self.callable_ui_action("ALL_OFF")
-			self.show_modal("admin")
+			self.show_modal("main")
 
 		elif i==2:
 			self.show_modal("alsa_mixer")


### PR DESCRIPTION
From instrument control screen:

+ short-back => step back on controller screen list
+ short-select => step forward on controller screen list
+ bold-back => preset screen
+ long-back => main menu
+ bold-learn => layer options
+ No direct access to snapshots. You have to navigate to main menu (long-back).

