### PR TITLE
Midi bank change

### DIFF
--- a/zyngine/zynthian_layer.py
+++ b/zyngine/zynthian_layer.py
@@ -449,14 +449,16 @@ class zynthian_layer:
 
 	def midi_control_change(self, chan, ccnum, ccval):
 		if ccnum==0x00: #MSB message
-			logging.debug("Setting System (0) | User (1) | Favorites (2) Bank: Receiving MIDI CH{}#CC{}={}".format(chan, ccnum, ccval))
+			logging.debug("Setting System (0) | User (1) | External USB (2) | Favorites (3) Bank: Receiving MIDI CH{}#CC{}={}".format(chan, ccnum, ccval))
 			if ccval < 0:
 				ccval = 0
-			elif ccval > 2:
-				ccval = 2
+			elif ccval > 3:
+				ccval = 3
 			self.bank_msb = ccval
 		elif ccnum==0x20: #LSB message
 			logging.info("Setting Bank: Receiving MIDI CH{}#CC{}={}".format(chan, ccnum, ccval))
+			logging.info("value of MSB var: "+str(self.bank_msb))
+			logging.info("value of favs available: "+str(self.favs_available))
 			if self.bank_msb == 0: #select system bank
 				self.set_bank(self.first_systembank_index + ccval)
 				self.load_preset_list()
@@ -467,6 +469,7 @@ class zynthian_layer:
 				self.set_bank(self.first_extbank_index + ccval)
 				self.load_preset_list()
 			elif self.bank_msb == 3 and self.favs_available: #select favorite bank
+				logging.info("doe maar gek")
 				self.set_bank(0)
 				self.load_preset_list()
 			else:

--- a/zyngine/zynthian_layer.py
+++ b/zyngine/zynthian_layer.py
@@ -153,9 +153,9 @@ class zynthian_layer:
 			elif self.bank_list[i][3] == "MY":
 				self.first_systembank_index = i + 1
 		logging.info("favorites available: "+str(self.favs_available))
-		logging.info("first external bank: "+str(self.first_extbank_index))
-		logging.info("first user bank: "+str(self.first_userbank_index))
-		logging.info("first system bank: "+str(self.first_systembank_index))
+		logging.info("first external bank index: "+str(self.first_extbank_index))
+		logging.info("first user bank index: "+str(self.first_userbank_index))
+		logging.info("first system bank index: "+str(self.first_systembank_index))
 		logging.debug("BANK LIST => \n%s" % str(self.bank_list))
 
 
@@ -457,8 +457,8 @@ class zynthian_layer:
 			self.bank_msb = ccval
 		elif ccnum==0x20: #LSB message
 			logging.info("Setting Bank: Receiving MIDI CH{}#CC{}={}".format(chan, ccnum, ccval))
-			logging.info("value of MSB var: "+str(self.bank_msb))
-			logging.info("value of favs available: "+str(self.favs_available))
+			logging.debug("value of MSB var: "+str(self.bank_msb))
+			logging.debug("value of favs available: "+str(self.favs_available))
 			if self.bank_msb == 0: #select system bank
 				self.set_bank(self.first_systembank_index + ccval)
 				self.load_preset_list()
@@ -469,7 +469,6 @@ class zynthian_layer:
 				self.set_bank(self.first_extbank_index + ccval)
 				self.load_preset_list()
 			elif self.bank_msb == 3 and self.favs_available: #select favorite bank
-				logging.info("doe maar gek")
 				self.set_bank(0)
 				self.load_preset_list()
 			else:

--- a/zyngine/zynthian_layer.py
+++ b/zyngine/zynthian_layer.py
@@ -45,8 +45,8 @@ class zynthian_layer:
 		self.midi_chan = midi_chan
 		self.bank_msb = 0
 		self.favs_available = False
-		self.first_extbank_index = 0
-		self.first_userbank_index = 0
+		self.first_extbank_index = -1
+		self.first_userbank_index = -1
 		self.first_systembank_index = 0
 
 		self.jackname = None
@@ -132,6 +132,10 @@ class zynthian_layer:
 
 
 	def load_bank_list(self):
+		self.favs_available = False
+		self.first_extbank_index = -1
+		self.first_userbank_index = -1
+		self.first_systembank_index = 0
 		self.bank_list = self.engine.get_bank_list(self)
 		if len(self.engine.get_preset_favs(self))>0:
 			self.bank_list = [["*FAVS*",0,"*** Favorites ***"]] + self.bank_list
@@ -139,7 +143,6 @@ class zynthian_layer:
 			start_index = 1
 			self.first_userbank_index = self.first_extbank_index = 1
 		else:
-			self.favorites = False
 			start_index = 0
 		logging.debug("start value: "+str(start_index))
 		logging.debug("length list: "+str(len(self.bank_list)))
@@ -457,15 +460,17 @@ class zynthian_layer:
 			if self.bank_msb == 0: #select system bank
 				self.set_bank(self.first_systembank_index + ccval)
 				self.load_preset_list()
-			elif self.bank_msb == 1: #select user bank
+			elif self.bank_msb == 1 and self.first_userbank_index != -1: #select user bank
 				self.set_bank(self.first_userbank_index + ccval)
 				self.load_preset_list()
-			elif self.bank_msb == 2: #select external bank
+			elif self.bank_msb == 2 and self.first_extbank_index != -1 : #select external bank
 				self.set_bank(self.first_extbank_index + ccval)
 				self.load_preset_list()
-			elif self.bank_msb == 3: #select favorite bank
-				self.set_bank(self.favs_available + ccval)
+			elif self.bank_msb == 3 and self.favs_available: #select favorite bank
+				self.set_bank(0)
 				self.load_preset_list()
+			else
+				logging.warning("Invalid LSB command")
 		elif self.engine:
 			#logging.debug("Receving MIDI CH{}#CC{}={}".format(chan, ccnum, ccval))
 

--- a/zyngine/zynthian_layer.py
+++ b/zyngine/zynthian_layer.py
@@ -469,7 +469,7 @@ class zynthian_layer:
 			elif self.bank_msb == 3 and self.favs_available: #select favorite bank
 				self.set_bank(0)
 				self.load_preset_list()
-			else
+			else:
 				logging.warning("Invalid LSB command")
 		elif self.engine:
 			#logging.debug("Receving MIDI CH{}#CC{}={}".format(chan, ccnum, ccval))

--- a/zyngui/zynthian_gui_layer.py
+++ b/zyngui/zynthian_gui_layer.py
@@ -1227,7 +1227,7 @@ class zynthian_gui_layer(zynthian_gui_selector):
 		try:
 			with open(fpath,"r") as fh:
 				json=fh.read()
-				logging.info("Loading snapshot %s => \n%s" % (fpath,json))
+				logging.debug("Loading snapshot %s => \n%s" % (fpath,json))
 		except Exception as e:
 			logging.error("Can't load snapshot '%s': %s" % (fpath,e))
 			return False


### PR DESCRIPTION
Solved the 403 error by replacing the fork. Implemented as follows:
When CC0 (MSB) is received, saved to flag var "bank_msb".
When CC32 (LSB) is received, bank changes, using the "bank_msb":
bank_msb==0 => system banks LSB (0-127)
bank_msb==1 => user bank LSB (0-127)
bank_msb==2 => external USB bank LSB (0-127)
bank_msb==3 => favourites bank, if it exist. In this case, lsb has not meaning.

Used following tests with database -> favorites, user & system banks and no external bank
MSB = 0 / LSB 1-x -> works
MSB = 1 / LSB 1-x -> works
MSB = 2 / LSB 0 -> throws invalid midi cc warning and keeps the current setting
MSB = 3 -> throws invalid midi cc warning since it can't load favorites in fluidsynth

Unrelated bugs: 
* Fluidsynth cannot select the favorites bank and throws an error when favorites bank is selected (see error log). Seems a separate issue. Don't know external bank ID, now named it "EXT". Probably needs updating.
* GUI is not updated in layer, bank and preset screen
* GUI is sometimes not updated in control screen

ps: Atom automatically removes spaces at the end of text, leading to some extra changes. Hope you don't mind :-)
