### PR TITLE
Fixes failure add notes from external MIDI device before snapshot loaded

### DIFF
--- a/zynlibs/zynseq/zynseq.cpp
+++ b/zynlibs/zynseq/zynseq.cpp
@@ -594,6 +594,7 @@ void init(char* name) {
     transportRequestTimebase();        
     transportStop("zynseq");
     transportLocate(0);
+    g_pTrack = g_seqMan.getSequence(0, 0)->getTrack(0);
 }
 
 bool isModified()
@@ -833,8 +834,7 @@ bool load(const char* filename)
     fclose(pFile);
     //printf("Ver: %d Loaded %lu patterns, %lu sequences, %lu banks from file %s\n", nVersion, m_mPatterns.size(), m_mSequences.size(), m_mBanks.size(), filename);
     g_bDirty = false;
-    Sequence* pSequence = g_seqMan.getSequence(0, 0);
-    g_pTrack = pSequence->getTrack(0);
+    g_pTrack = g_seqMan.getSequence(0, 0)->getTrack(0);
     return true;
 }
 


### PR DESCRIPTION
The track used for pattern editor was not being set until a snapshot is loaded. This probably chaged behaviour when sequences were added to snapshot and only noticed on first use before any snapshots (including last state) were loaded. Now select the track on library initiation. (It is unset at begining of load and set at end of load to stop playback /editing whilst snapshots are being loaded.)