### PR TITLE
Feature/327 zynseq short notes

### DIFF
--- a/zyngui/zynthian_gui_patterneditor.py
+++ b/zyngui/zynthian_gui_patterneditor.py
@@ -37,6 +37,7 @@ from time import sleep
 from datetime import datetime
 import time
 import ctypes
+from math import ceil
 from os.path import dirname, realpath, basename
 from zynlibs.zynsmf import zynsmf # Python wrapper for zynsmf (ensures initialised and wraps load() function)
 from zynlibs.zynsmf.zynsmf import libsmf # Direct access to shared library
@@ -70,6 +71,10 @@ ENC_BACK            = 1
 ENC_SNAPSHOT        = 2
 ENC_SELECT          = 3
 
+EDIT_MODE_NONE		= 0 # Edit mode disabled
+EDIT_MODE_SINGLE	= 1 # Edit mode enabled for selected note
+EDIT_MODE_ALL		= 2 # Edit mode enabled for all notes
+
 # List of permissible steps per beat
 STEPS_PER_BEAT = [1,2,3,4,6,8,12,24]
 
@@ -84,7 +89,7 @@ class zynthian_gui_patterneditor():
 
 		os.makedirs(CONFIG_ROOT, exist_ok=True)
 
-		self.edit_mode = False # True to enable encoders to adjust duration and velocity
+		self.edit_mode = EDIT_MODE_NONE # Enable encoders to adjust duration and velocity
 		self.zoom = 16 # Quantity of rows (notes) displayed in grid
 		self.duration = 1.0 # Current note entry duration
 		self.velocity = 100 # Current note entry velocity
@@ -225,7 +230,7 @@ class zynthian_gui_patterneditor():
 		self.parent.unregister_switch(zynthian_gui_stepsequencer.ENC_SNAPSHOT, "SB")
 		libseq.setPlayState(self.bank, self.sequence, zynthian_gui_stepsequencer.SEQ_STOPPED)
 		libseq.enableMidiInput(False)
-		self.enable_edit(False)
+		self.enable_edit(EDIT_MODE_NONE)
 		libseq.setRefNote(self.keymap_offset)
 
 
@@ -267,20 +272,23 @@ class zynthian_gui_patterneditor():
 
 
 	# Function to set edit mode
-	def enable_edit(self, enable):
-		if enable:
-			self.edit_mode = True
-			self.parent.register_switch(ENC_BACK, self)
-			self.parent.set_title("Note Parameters", zynthian_gui_config.color_header_bg, zynthian_gui_config.color_panel_tx)
-			self.parent.register_zyncoder(ENC_SNAPSHOT, self)
-			self.parent.register_zyncoder(ENC_LAYER, self)
+	def enable_edit(self, mode):
+		if mode <= EDIT_MODE_ALL:
+			self.edit_mode = mode
+			if mode:
+				self.parent.register_switch(ENC_BACK, self)
+				self.parent.register_zyncoder(ENC_SNAPSHOT, self)
+				self.parent.register_zyncoder(ENC_LAYER, self)
+				if mode == EDIT_MODE_SINGLE:
+					self.parent.set_title("Note Parameters", zynthian_gui_config.color_header_bg, zynthian_gui_config.color_panel_tx)
+				else:
+					self.parent.set_title("Note Parameters ALL", zynthian_gui_config.color_header_bg, zynthian_gui_config.color_panel_tx)
 
-		else:
-			self.edit_mode = False
-			self.parent.unregister_switch(ENC_BACK)
-			self.parent.unregister_zyncoder(ENC_SNAPSHOT)
-			self.parent.unregister_zyncoder(ENC_LAYER)
-			self.parent.set_title(self.title, zynthian_gui_config.color_panel_tx, zynthian_gui_config.color_header_bg)
+			else:
+				self.parent.unregister_switch(ENC_BACK)
+				self.parent.unregister_zyncoder(ENC_SNAPSHOT)
+				self.parent.unregister_zyncoder(ENC_LAYER)
+				self.parent.set_title(self.title, zynthian_gui_config.color_panel_tx, zynthian_gui_config.color_header_bg)
 
 
 	# Function to assert steps per beat
@@ -740,8 +748,8 @@ class zynthian_gui_patterneditor():
 		row = index - self.keymap_offset
 		note = self.keymap[index]['note']
 		# Skip hidden (overlapping) cells
-		for previous in range(step - 1, -1, -1):
-			prev_duration = libseq.getNoteDuration(previous, note)
+		for previous in range(int(step) - 1, -1, -1):
+			prev_duration = ceil(libseq.getNoteDuration(previous, note))
 			if not prev_duration:
 				continue
 			if prev_duration > step - previous:
@@ -754,7 +762,7 @@ class zynthian_gui_patterneditor():
 			step = 0
 		if step >= libseq.getSteps():
 			step = libseq.getSteps() - 1
-		self.selected_cell = [step, index]
+		self.selected_cell = [int(step), index]
 		cell = self.grid_canvas.find_withtag("selection")
 		duration = libseq.getNoteDuration(step, row)
 		if not duration:
@@ -925,7 +933,7 @@ class zynthian_gui_patterneditor():
 		libseq.selectPattern(index)
 		libseq.addPattern(self.bank, self.sequence, 0, 0, index)
 		if self.selected_cell[0] >= libseq.getSteps():
-			self.selected_cell[0] = libseq.getSteps() - 1
+			self.selected_cell[0] = int(libseq.getSteps()) - 1
 		self.keymap_offset = libseq.getRefNote()
 		self.load_keymap()
 		self.redraw_pending = 2
@@ -948,7 +956,7 @@ class zynthian_gui_patterneditor():
 	#   value: Current value of zyncoder
 	def on_zyncoder(self, encoder, value):
 		if encoder == ENC_BACK:
-			if self.edit_mode:
+			if self.edit_mode == EDIT_MODE_SINGLE:
 				self.velocity = self.velocity + value
 				if self.velocity > 127:
 					self.velocity = 127
@@ -962,11 +970,14 @@ class zynthian_gui_patterneditor():
 					libseq.setNoteVelocity(self.selected_cell[0], note, self.velocity)
 					self.draw_cell(self.selected_cell[0], self.selected_cell[1])
 				self.parent.set_title("Velocity: %d" % (self.velocity), None, None, 2)
+			elif self.edit_mode == EDIT_MODE_ALL:
+				libseq.changeVelocityAll(value)
+				self.parent.set_title("ALL Velocity", None, None, 2)
 			else:
 				self.select_cell(None, self.selected_cell[1] - value)
 
 		elif encoder == ENC_SELECT:
-			if self.edit_mode:
+			if self.edit_mode == EDIT_MODE_SINGLE:
 				if value > 0:
 					self.duration = self.duration + 1
 				if value < 0:
@@ -983,11 +994,17 @@ class zynthian_gui_patterneditor():
 				else:
 					self.select_cell()
 				self.parent.set_title("Duration: %0.1f steps" % (self.duration), None, None, 2)
+			elif self.edit_mode == EDIT_MODE_ALL:
+				if value > 0:
+					libseq.changeDurationAll(1)
+				if value < 0:
+					libseq.changeDurationAll(-1)
+				self.parent.set_title("ALL DURATION", None, None, 2)
 			else:
 				self.select_cell(self.selected_cell[0] + value, None)
 
 		elif encoder == ENC_SNAPSHOT:
-			if self.edit_mode:
+			if self.edit_mode == EDIT_MODE_SINGLE:
 				if value > 0:
 					self.duration = self.duration + 0.1
 				if value < 0:
@@ -1004,6 +1021,12 @@ class zynthian_gui_patterneditor():
 				else:
 					self.select_cell()
 				self.parent.set_title("Duration: %0.1f steps" % (self.duration), None, None, 2)
+			elif self.edit_mode == EDIT_MODE_ALL:
+				if value > 0:
+					libseq.changeDurationAll(0.1)
+				if value < 0:
+					libseq.changeDurationAll(-0.1)
+				self.parent.set_title("ALL DURATION", None, None, 2)
 
 #		elif encoder == ENC_LAYER and not self.parent.lst_menu.winfo_viewable():
 			# Show menu
@@ -1021,15 +1044,18 @@ class zynthian_gui_patterneditor():
 		if self.parent.param_editor_item:
 			return False
 		if switch == ENC_SELECT:
-			if self.edit_mode:
-				self.enable_edit(False)
-				return True
 			if type == "S":
+				if self.edit_mode:
+					self.enable_edit(EDIT_MODE_NONE)
+					return True
 				note = self.toggle_event(self.selected_cell[0], self.selected_cell[1])
 				if note:
 					self.play_note(note)
-			else:
-				self.enable_edit(True)
+			elif type == "B":
+				if self.edit_mode == EDIT_MODE_NONE:
+					self.enable_edit(EDIT_MODE_SINGLE)
+				else:
+					self.enable_edit(EDIT_MODE_ALL)
 			return True
 		elif switch == ENC_SNAPSHOT:
 			if type == "B":
@@ -1041,7 +1067,7 @@ class zynthian_gui_patterneditor():
 				libseq.setPlayState(self.bank, self.sequence, zynthian_gui_stepsequencer.SEQ_STOPPED)
 			return True
 		elif switch == ENC_BACK:
-			self.enable_edit(False)
+			self.enable_edit(EDIT_MODE_NONE)
 			return True
 		return False
 

--- a/zyngui/zynthian_gui_patterneditor.py
+++ b/zyngui/zynthian_gui_patterneditor.py
@@ -182,7 +182,7 @@ class zynthian_gui_patterneditor():
 
 	def play_note(self, note):
 		if libseq.getPlayState(self.bank, self.sequence) == zynthian_gui_stepsequencer.SEQ_STOPPED:
-			libseq.playNote(note, 100, self.channel, 200)
+			libseq.playNote(note, self.velocity, self.channel, int(200 * self.duration))
 
 
 	#Function to set values of encoders

--- a/zyngui/zynthian_gui_stepsequencer.py
+++ b/zyngui/zynthian_gui_stepsequencer.py
@@ -687,7 +687,7 @@ class zynthian_gui_stepsequencer(zynthian_gui_base.zynthian_gui_base):
 					self.param_editor_reset()
 					return True
 
-		return False # Tell parent that handle the rest of short and bold key presses
+		return False # Tell parent to handle the rest of short and bold key presses
 
 
 	# Function to manage switch press

--- a/zynlibs/zynseq/file_format.txt
+++ b/zynlibs/zynseq/file_format.txt
@@ -1,6 +1,6 @@
 zynseq file format (RIFF)
 =========================
-Version 6
+Version 7
 Pattern time is measured in steps.
 Sequence time is measured in MIDI clock cycles.
 
@@ -31,7 +31,7 @@ Block:
 	Padding [1] (Added in V5)
 	Events: (quantity deduced from block length)
 		Start step [4]
-		Duration [4]
+		Duration [4] (V7 change to BCD-LE e.g. 0x0408 is 8.4)
 		Command [1]
 		Value 1 start [1]
 		Value 2 start [1]

--- a/zynlibs/zynseq/pattern.cpp
+++ b/zynlibs/zynseq/pattern.cpp
@@ -14,7 +14,6 @@ Pattern::~Pattern()
 
 StepEvent* Pattern::addEvent(uint32_t position, uint8_t command, uint8_t value1, uint8_t value2, float duration)
 {
-    printf("Pattern::addEvent duration=%f\n", duration);
     //Delete overlapping events
     for(auto it = m_vEvents.begin(); it!=m_vEvents.end(); ++it)
     {
@@ -244,6 +243,36 @@ void Pattern::transpose(int value)
             (*it).setValue1start(note);
             (*it).setValue1end(note);
         }
+    }
+}
+
+void Pattern::changeVelocityAll(int value)
+{
+    for(auto it = m_vEvents.begin(); it != m_vEvents.end(); ++it)
+    {
+        if((*it).getCommand() != MIDI_NOTE_ON)
+            continue;
+        int vel = (*it).getValue2start() + value;
+        if(vel > 127)
+            vel = 127;
+        if(vel < 1)
+            vel = 1;
+        (*it).setValue2start(vel);
+    }
+}
+
+void Pattern::changeDurationAll(float value)
+{
+    for(auto it = m_vEvents.begin(); it != m_vEvents.end(); ++it)
+    {
+        if((*it).getCommand() != MIDI_NOTE_ON)
+            continue;
+        float duration = (*it).getDuration() + value;
+        if(duration <= 0)
+            return; // Don't allow jump larger than current value
+        if(duration < 0.1) //!@todo How short should we allow duration change?
+            duration = 0.1;
+        (*it).setDuration(duration);
     }
 }
 

--- a/zynlibs/zynseq/pattern.h
+++ b/zynlibs/zynseq/pattern.h
@@ -15,7 +15,7 @@ class StepEvent
         StepEvent()
         {
             m_nPosition = 0;
-            m_nDuration = 1;
+            m_fDuration = 1.0;
             m_nCommand = MIDI_NOTE_ON;
             m_nValue1start = 60;
             m_nValue2start = 100;
@@ -25,10 +25,10 @@ class StepEvent
 
         /** Constructor - create an instance of StepEvent object
         */
-        StepEvent(uint32_t position, uint8_t command, uint8_t value1 = 0, uint8_t value2 = 0, uint32_t duration = 1)
+        StepEvent(uint32_t position, uint8_t command, uint8_t value1 = 0, uint8_t value2 = 0, float duration = 1.0)
         {
             m_nPosition = position;
-            m_nDuration = duration;
+            m_fDuration = duration;
             m_nCommand = command;
             m_nValue1start = value1;
             m_nValue2start = value2;
@@ -43,7 +43,7 @@ class StepEvent
         StepEvent(StepEvent* pEvent)
         {
             m_nPosition = pEvent->getPosition();
-            m_nDuration = pEvent->getDuration();
+            m_fDuration = pEvent->getDuration();
             m_nCommand = pEvent->getCommand();
             m_nValue1start = pEvent->getValue1start();
             m_nValue2start = pEvent->getValue2start();
@@ -51,21 +51,21 @@ class StepEvent
             m_nValue2end = pEvent->getValue2end();
         };
         uint8_t getPosition() { return m_nPosition; };
-        uint8_t getDuration() { return m_nDuration; };
+        float getDuration() { return m_fDuration; };
         uint8_t getCommand() { return m_nCommand; };
         uint8_t getValue1start() { return m_nValue1start; };
         uint8_t getValue2start() { return m_nValue2start; };
         uint8_t getValue1end() { return m_nValue1end; };
         uint8_t getValue2end() { return m_nValue2end; };
         void setPosition(uint32_t position) { m_nPosition = position; };
-        void setDuration(uint32_t duration) { m_nDuration = duration; };
+        void setDuration(float duration) { m_fDuration = duration; };
         void setValue1start(uint8_t value) { m_nValue1start = value; };
         void setValue2start(uint8_t value) { m_nValue2start = value; };
         void setValue1end(uint8_t value) { m_nValue1end = value; };
         void setValue2end(uint8_t value) { m_nValue2end = value; };
     private:
         uint32_t m_nPosition; // Start position of event in steps
-        uint32_t m_nDuration; // Duration of event in steps
+        float m_fDuration; // Duration of event in steps
         uint8_t m_nCommand; // MIDI command without channel
         uint8_t m_nValue1start; // MIDI value 1 at start of event
         uint8_t m_nValue2start; // MIDI value 2 at start of event
@@ -84,7 +84,7 @@ class Pattern
         *   @param  stepsPerBeat Quantity of steps per beat [Optional - default: 4]
         */
         Pattern(uint32_t beats = 4, uint8_t stepsPerBeat = 4);
-        
+
         /** @brief  Destruct pattern object
         */
         ~Pattern();
@@ -96,7 +96,7 @@ class Pattern
         *   @param  value2 MIDI value 2
         *   @param  duration Event duration in steps cycles
         */
-        StepEvent* addEvent(uint32_t position, uint8_t command, uint8_t value1 = 0, uint8_t value2 = 0, uint32_t duration = 1);
+        StepEvent* addEvent(uint32_t position, uint8_t command, uint8_t value1 = 0, uint8_t value2 = 0, float duration = 1.0);
 
         /** @brief  Add event from existing event
         *   @param  pEvent Pointer to event to copy
@@ -111,7 +111,7 @@ class Pattern
         *   @param  duration Duration of note in steps
         *   @retval bool True on success
         */
-        bool addNote(uint32_t step, uint8_t note, uint8_t velocity, uint32_t duration = 1);
+        bool addNote(uint32_t step, uint8_t note, uint8_t velocity, float duration = 1.0);
 
         /** @brief  Remove note from pattern
         *   @param  position Quantity of steps from start of pattern at which to remove note
@@ -136,9 +136,9 @@ class Pattern
         /** @brief  Get duration of note
         *   @param  position Quantity of steps from start of pattern at which note starts
         *   @param  note MIDI note number
-        *   @retval uint32_t Duration of note or 0 if note does not exist
+        *   @retval float Duration of note or 0 if note does not exist
         */
-        uint8_t getNoteDuration(uint32_t step, uint8_t note);
+        float getNoteDuration(uint32_t step, uint8_t note);
 
         /** @brief  Add continuous controller to pattern
         *   @param  position Quantity of steps from start of pattern at which control starts
@@ -147,7 +147,7 @@ class Pattern
         *   @param  valueEnd Controller value at end of event
         *   @param  duration Duration of event in steps
         */
-        void addControl(uint32_t step, uint8_t control, uint8_t valueStart, uint8_t valueEnd, uint32_t duration = 1);
+        void addControl(uint32_t step, uint8_t control, uint8_t valueStart, uint8_t valueEnd, float duration = 1.0);
 
         /** @brief  Remove continuous controller from pattern
         *   @param  position Quantity of steps from start of pattern at which control starts
@@ -158,9 +158,9 @@ class Pattern
         /** @brief  Get duration of controller event
         *   @param  position Quantity of steps from start of pattern at which control starts
         *   @param  control MIDI controller number
-        *   @retval uint32_t Duration of control or 0 if control does not exist
+        *   @retval float Duration of control or 0 if control does not exist
         */
-        uint8_t getControlDuration(uint32_t step, uint8_t control);
+        float getControlDuration(uint32_t step, uint8_t control);
 
         /** @brief  Get quantity of steps in pattern
         *   @retval uint32_t Quantity of steps
@@ -187,12 +187,12 @@ class Pattern
         *   @retval uint32_t Quantity of steps per beat
         */
         uint32_t getStepsPerBeat();
-        
+
         /** @brief  Set beats in pattern
         *   @param  beats Quantity of beats in pattern
         */
         void setBeatsInPattern(uint32_t beats);
-        
+
         /** @brief  Get beats in pattern
         *   @retval uint32_t Quantity of beats in pattern
         */
@@ -226,7 +226,7 @@ class Pattern
         /** @brief  Clear all events from pattern
         */
         void clear();
-        
+
         /** @brief  Get event at given index
         *   @param  index Index of event
         *   @retval StepEvent* Pointer to event or null if event does not existing
@@ -243,13 +243,13 @@ class Pattern
         *   @note   May be used for position within user interface
         */
         uint8_t getRefNote();
-        
+
         /** @brief  Set the reference note
         *   @param  MIDI note number
          May be used for position within user interface
         */
         void setRefNote(uint8_t note);
-        
+
         /** @brief  Get last populated step
         *   @retval uint32_t Index of last step that contains any events or -1 if pattern is empty
         */

--- a/zynlibs/zynseq/pattern.h
+++ b/zynlibs/zynseq/pattern.h
@@ -223,6 +223,16 @@ class Pattern
         */
         void transpose(int value);
 
+        /** @brief  Change velocity of all notes in patterm
+        *   @param  value Offset to adjust +/-127
+        */
+        void changeVelocityAll(int value);
+
+        /** @brief  Change duration of all notes in patterm
+        *   @param  value Offset to adjust +/-100.0 or whatever
+        */
+        void changeDurationAll(float value);
+
         /** @brief  Clear all events from pattern
         */
         void clear();

--- a/zynlibs/zynseq/zynseq.cpp
+++ b/zynlibs/zynseq/zynseq.cpp
@@ -1281,6 +1281,25 @@ void transpose(int8_t value)
     g_bDirty = true;
 }
 
+void changeVelocityAll(int value)
+{
+    if(!g_pPattern)
+        return;
+    g_bPatternModified = true;
+    g_pPattern->changeVelocityAll(value);
+    g_bDirty = true;
+}
+
+void changeDurationAll(float value)
+{
+    if(!g_pPattern)
+        return;
+    g_bPatternModified = true;
+    g_pPattern->changeDurationAll(value);
+    g_bDirty = true;
+}
+
+
 void clear()
 {
     if(!g_pPattern)

--- a/zynlibs/zynseq/zynseq.cpp
+++ b/zynlibs/zynseq/zynseq.cpp
@@ -35,7 +35,7 @@
 #include <string>
 #include <cstring> //provides strcmp
 
-#define FILE_VERSION 6
+#define FILE_VERSION 7
 
 #define DPRINTF(fmt, args...) if(g_bDebug) printf(fmt, ## args)
 
@@ -735,14 +735,14 @@ bool load(const char* filename)
                 if(checkBlock(pFile, nBlockSize, 14))
                     break;
                 uint32_t nStep = fileRead32(pFile);
-                uint32_t nDuration = fileRead32(pFile);
+                float fDuration = float(fileRead16(pFile))/100 + fileRead16(pFile); // fractional + integral (BCD)
                 uint8_t nCommand = fileRead8(pFile);
                 uint8_t nValue1start = fileRead8(pFile);
                 uint8_t nValue2start = fileRead8(pFile);
                 uint8_t nValue1end = fileRead8(pFile);
                 uint8_t nValue2end = fileRead8(pFile);
                 fileRead8(pFile); // Padding
-                StepEvent* pEvent = pPattern->addEvent(nStep, nCommand, nValue1start, nValue2start, nDuration);
+                StepEvent* pEvent = pPattern->addEvent(nStep, nCommand, nValue1start, nValue2start, fDuration);
                 pEvent->setValue1end(nValue1end);
                 pEvent->setValue2end(nValue2end);
                 nBlockSize -= 14;
@@ -885,7 +885,11 @@ void save(const char* filename)
             while(StepEvent* pEvent = pPattern->getEventAt(nEvent++))
             {
                 nPos += fileWrite32(pEvent->getPosition(), pFile);
-                nPos += fileWrite32(pEvent->getDuration(), pFile);
+                float fDuration = pEvent->getDuration();
+                uint16_t nUnits = uint16_t(fDuration);
+                uint16_t nDecimal = uint16_t((fDuration - nUnits) * 100);
+                nPos += fileWrite16(nDecimal, pFile); // fractional (BCD)
+                nPos += fileWrite16(nUnits, pFile); // integral (BCD)
                 nPos += fileWrite8(pEvent->getCommand(), pFile);
                 nPos += fileWrite8(pEvent->getValue1start(), pFile);
                 nPos += fileWrite8(pEvent->getValue2start(), pFile);
@@ -1227,7 +1231,7 @@ void setStepsPerBeat(uint32_t steps)
     g_bDirty = true;
 }
 
-bool addNote(uint32_t step, uint8_t note, uint8_t velocity, uint32_t duration)
+bool addNote(uint32_t step, uint8_t note, uint8_t velocity, float duration)
 {
     if(!g_pPattern)
         return false;
@@ -1261,7 +1265,7 @@ void setNoteVelocity(uint32_t step, uint8_t note, uint8_t velocity)
     g_bDirty = true;
 }
 
-uint32_t getNoteDuration(uint32_t step, uint8_t note)
+float getNoteDuration(uint32_t step, uint8_t note)
 {
     if(g_pPattern)
         return g_pPattern->getNoteDuration(step, note);

--- a/zynlibs/zynseq/zynseq.h
+++ b/zynlibs/zynseq/zynseq.h
@@ -306,6 +306,16 @@ float getNoteDuration(uint32_t step, uint8_t note);
 */
 void transpose(int8_t value);
 
+/** @brief  Change velocity of all notes in patterm
+*   @param  value Offset to adjust +/-127
+*/
+void changeVelocityAll(int value);
+
+/** @brief  Change duration of all notes in patterm
+*   @param  value Offset to adjust +/-100.0 or whatever
+*/
+void changeDurationAll(float value);
+
 /** @brief  Clears events from selected pattern
 *   @note   Does not change other parameters such as pattern length
 */

--- a/zynlibs/zynseq/zynseq.h
+++ b/zynlibs/zynseq/zynseq.h
@@ -272,7 +272,7 @@ void setStepsPerBeat(uint32_t steps);
 *   @param  duration Quantity of steps note should play for
 *   @retval bool True on success
 */
-bool addNote(uint32_t step, uint8_t note, uint8_t velocity, uint32_t duration);
+bool addNote(uint32_t step, uint8_t note, uint8_t velocity, float duration);
 
 /** @brief  Removes note from selected pattern
 *   @param  step Index of step at which to remove note
@@ -283,6 +283,7 @@ void removeNote(uint32_t step, uint8_t note);
 /** @brief  Get velocity of note in selected pattern
 *   @param  step Index of step at which note resides
 *   @param  note MIDI note number
+*   @retval uint8_t Note velocity (0..127)
 */
 uint8_t getNoteVelocity(uint32_t step, uint8_t note);
 
@@ -296,9 +297,9 @@ void setNoteVelocity(uint32_t step, uint8_t note, uint8_t velocity);
 /** @brief  Get duration of note in selected pattern
 *   @param  position Index of step at which note starts
 *   @note   note MIDI note number
-*   @retval uint32_t Duration in steps or 0 if note does not exist
+*   @retval float Duration in steps or 0.0 if note does not exist
 */
-uint32_t getNoteDuration(uint32_t step, uint8_t note);
+float getNoteDuration(uint32_t step, uint8_t note);
 
 /** @brief  Transpose selected pattern
 *   @param  value +/- quantity of notes to transpose
@@ -398,7 +399,7 @@ uint32_t getPatternPlayhead(uint8_t bank, uint8_t sequence, uint32_t track);
 *   @param  track Index of track
 *   @param  position Quantity of clock cycles from start of track at which to add pattern
 *   @param  pattern Index of pattern
-*   @param  force True to remove overlapping patterns, false to fail if overlapping patterns 
+*   @param  force True to remove overlapping patterns, false to fail if overlapping patterns
 *   @retval True if pattern inserted
 */
 bool addPattern(uint8_t bank, uint8_t sequence, uint32_t track, uint32_t position, uint32_t pattern, bool force);

--- a/zynlibs/zynseq/zynseq.py
+++ b/zynlibs/zynseq/zynseq.py
@@ -49,6 +49,8 @@ def init():
 		libseq=ctypes.cdll.LoadLibrary(dirname(realpath(__file__))+"/build/libzynseq.so")
 		libseq.getSequenceName.restype = ctypes.c_char_p
 		libseq.getTempo.restype = ctypes.c_double
+		libseq.getNoteDuration.restype = ctypes.c_float
+		libseq.addNote.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_float]
 	except Exception as e:
 		libseq=None
 		print("Can't initialise zynseq library: %s" % str(e))

--- a/zynlibs/zynseq/zynseq.py
+++ b/zynlibs/zynseq/zynseq.py
@@ -51,6 +51,7 @@ def init():
 		libseq.getTempo.restype = ctypes.c_double
 		libseq.getNoteDuration.restype = ctypes.c_float
 		libseq.addNote.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_float]
+		libseq.changeDurationAll.argtypes = [ctypes.c_float]
 	except Exception as e:
 		libseq=None
 		print("Can't initialise zynseq library: %s" % str(e))


### PR DESCRIPTION
Adds ability to change note length in 0.1 steps using snapshot encoder. Fixes issue zynthian/zynthian-issue-tracking/issues/327.
Adds ability to change note length and velocity of all notes in a pattern simultaneously by bold pressing when already in edit mode.