### PR TITLE
zynaddsubfx: start in user preset directory

### DIFF
--- a/zyngine/zynthian_engine_zynaddsubfx.py
+++ b/zyngine/zynthian_engine_zynaddsubfx.py
@@ -130,6 +130,8 @@ class zynthian_engine_zynaddsubfx(zynthian_engine):
 		else:
 			self.command = "zynaddsubfx -r {} -b {} -O jack-multi -I jack -P {} -a -U".format(self.sr, self.bs, self.osc_target_port)
 
+		self.command_cwd = zynthian_engine.my_data_dir + "/presets/zynaddsubfx"
+
 		self.command_prompt = "\n\\[INFO] Main Loop..."
 
 		self.osc_paths_data = []


### PR DESCRIPTION
Change cwd and set PWD to /zynthian/zynthian-my-data/presets/zynaddsubfx
before starting zynaddsubfx to cause that directory to be used as the
initial root for presets, which eases the loading and saving of presets
(instrument files and/or master files).

This fixes https://github.com/zynthian/zynthian-issue-tracking/issues/592 .