### PR TITLE
Partly revert 'Improve selector UX by using 1 tick...' (#607)

### DIFF
--- a/zyngui/zynthian_gui_controller.py
+++ b/zyngui/zynthian_gui_controller.py
@@ -541,8 +541,8 @@ class zynthian_gui_controller:
 					self.inverted=True
 				if (isinstance(zctrl.midi_cc, int) and zctrl.midi_cc>0):
 					self.max_value=127
-					#self.step=max(1,int(16/self.n_values))
-					self.step = 1
+					self.step=max(1,int(16/self.n_values))
+					#self.step = 1
 					val=zctrl.value-zctrl.value_min
 				else:
 					self.selmode = True


### PR DESCRIPTION
Partly revert 'Improve selector UX by using 1 tick/detent on
zyncoders.' in order to get binary CC parameters (such as
ZynAddSubFX portamento on/off) to be changable (otherwise it's
not possible to change the value from the Zynthian gui).

I'm not sure this is the correct fix, as it now potentially requires two ticks to change the parameter value, but at least it's now possible to change the parameter value, and with two-valued parameters the number of clicks is not significant (if it's small enough) IMHO.