### PR TITLE
Fixes #604 - check wsled exists before accessing

### DIFF
--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -1829,7 +1829,8 @@ class zynthian_gui:
 			if self.wsleds:
 				self.update_wsleds()
 			sleep(0.2)
-		self.end_wsleds()
+		if self.wsleds:
+			self.end_wsleds()
 
 
 	def refresh_status(self):


### PR DESCRIPTION
Simple fix. Just check the object exists.