### PR TITLE
Fixes #630 - Refresh mixer after program change

### DIFF
--- a/zyngui/zynthian_gui_mixer.py
+++ b/zyngui/zynthian_gui_mixer.py
@@ -707,8 +707,6 @@ class zynthian_gui_mixer(zynthian_gui_base.zynthian_gui_base):
 
 	# Function to handle showing display
 	def show(self):
-		if self.shown:
-			return
 		self.zyngui.screens["control"].unlock_controllers()
 		self.refresh_visible_strips()
 		if self.selected_chain_index == None:


### PR DESCRIPTION
Simple fix - remove check for mixer screen shown upon show. Hopefully it won't cause loops or flicker. Tests of common workflows seem okay.