### PR TITLE
Zyngine: Set correct CWD for zynaddsubfx browser access

### DIFF
--- a/zyngine/zynthian_engine_zynaddsubfx.py
+++ b/zyngine/zynthian_engine_zynaddsubfx.py
@@ -157,7 +157,7 @@ class zynthian_engine_zynaddsubfx(zynthian_engine):
 
 		# Zynaddsubfx which uses PWD as the root for presets, due to the fltk
 		# toolkit used for the gui file browser.
-		self.command_cwd = zynthian_engine.my_data_dir + "/presets/zynaddsubfx"
+		self.command_cwd = zynthian_engine.my_data_dir + "/presets"
 
 		self.command_prompt = "\n\\[INFO] Main Loop..."
 


### PR DESCRIPTION
In order for user banks
(i.e./zynthian/zynthian-my-data/presets/zynaddsubfx/banks)
to be recognized and listed in the BANK column in the
Browser, CWD must be set to the directory containing zynaddsubfx/
(i.e./zynthian/zynthian-my-data/presets/).

This has the disadvantage the for operations in the File menu,
the starting directory will be /zynthian/zynthian-my-data/presets/,
so the first file operation after startup must start with clicking
on zynaddsubfx/ (/and then the appropriate subdirectory, e.g. banks/).

It is deemed however, that the ability for the Browser pane to
correctly find and identify user banks is of greater importance.
Hence the change of startup directory.