### PR TITLE
Fix closing crash

### DIFF
--- a/zynautoconnect/zynthian_autoconnect.py
+++ b/zynautoconnect/zynthian_autoconnect.py
@@ -715,6 +715,7 @@ def start(rt=2):
 	# Start Autoconnect Thread
 	thread=Thread(target=autoconnect_thread, args=())
 	thread.daemon = True # thread dies with the program
+	thread.name = "autoconnect"
 	thread.start()
 
 

--- a/zynautoconnect/zynthian_autoconnect.py
+++ b/zynautoconnect/zynthian_autoconnect.py
@@ -725,6 +725,7 @@ def stop():
 	acquire_lock()
 	audio_disconnect_sysout()
 	release_lock()
+	jclient.deactivate()
 
 
 def is_running():

--- a/zyngine/zynthian_engine_mixer.py
+++ b/zyngine/zynthian_engine_mixer.py
@@ -415,6 +415,7 @@ class zynthian_engine_mixer(zynthian_engine):
 
 		self.sender_poll_enabled = True
 		thread = threading.Thread(target=runInThread, daemon=True)
+		thread.name = "engine mixer"
 		thread.start()
 
 

--- a/zyngine/zynthian_engine_modui.py
+++ b/zyngine/zynthian_engine_modui.py
@@ -307,6 +307,7 @@ class zynthian_engine_modui(zynthian_engine):
 
 		if i<100:
 			self.ws_thread=Thread(target=self.task_websocket, args=())
+			self.ws_thread.name = "modui"
 			self.ws_thread.daemon = True # thread dies with the program
 			self.ws_thread.start()
 			

--- a/zyngui/zynthian_gui_admin.py
+++ b/zyngui/zynthian_gui_admin.py
@@ -220,6 +220,7 @@ class zynthian_gui_admin(zynthian_gui_selector):
 			logging.info("Starting Command Sequence ...")
 			self.commands=cmds
 			self.thread=Thread(target=self.execute_commands, args=())
+			self.thread.name = "command sequence"
 			self.thread.daemon = True # thread dies with the program
 			self.thread.start()
 
@@ -258,6 +259,7 @@ class zynthian_gui_admin(zynthian_gui_selector):
 			logging.info("Starting Command Sequence ...")
 			self.commands=cmds
 			self.thread=Thread(target=self.killable_execute_commands, args=())
+			self.thread.name = "killable command sequence"
 			self.thread.daemon = True # thread dies with the program
 			self.thread.start()
 

--- a/zyngui/zynthian_gui_audio_recorder.py
+++ b/zyngui/zynthian_gui_audio_recorder.py
@@ -337,6 +337,7 @@ class zynthian_gui_audio_recorder(zynthian_gui_selector):
 				return
 
 			thread = threading.Thread(target=runInThread, args=(self.end_playing, cmd), daemon=True)
+			thread.name = "audio recorder"
 			thread.start()
 			sleep(0.5)
 			self.zyngui.zynautoconnect_audio()

--- a/zyngui/zynthian_gui_autoeq.py
+++ b/zyngui/zynthian_gui_autoeq.py
@@ -105,6 +105,7 @@ class zynthian_gui_autoeq():
 
 	def start_autoeq_thread(self):
 		self.autoeq_thread=Thread(target=self.autoeq_thread_task, args=())
+		self.autoeq_thread.name = "autoeq"
 		self.autoeq_thread.daemon = True # thread dies with the program
 		self.autoeq_thread.start()
 

--- a/zyngui/zynthian_gui_touchscreen_calibration.py
+++ b/zyngui/zynthian_gui_touchscreen_calibration.py
@@ -378,6 +378,7 @@ class zynthian_gui_touchscreen_calibration:
 			self.main_frame.grid()
 			self.onTimer()
 			self.detect_thread = Thread(target=self.detectDevice, args=(), daemon=True)
+			self.detect_thread.name = "touchscreen calibrate"
 			self.detect_thread.start()
 
 

--- a/zyngui/zynthian_widget_base.py
+++ b/zyngui/zynthian_widget_base.py
@@ -83,6 +83,7 @@ class zynthian_widget_base():
 
 	def start_mon_thread(self):
 		self.mon_thread=Thread(target=self.mon_thread_task, args=())
+		self.mon_thread.name = "widget monitor"
 		self.mon_thread.daemon = True # thread dies with the program
 		self.mon_thread.start()
 

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -1707,6 +1707,7 @@ class zynthian_gui:
 
 	def start_control_thread(self):
 		self.control_thread=Thread(target=self.control_thread_task, args=())
+		self.control_thread.name = "control"
 		self.control_thread.daemon = True # thread dies with the program
 		self.control_thread.start()
 
@@ -1738,6 +1739,7 @@ class zynthian_gui:
 
 	def start_loading_thread(self):
 		self.loading_thread=Thread(target=self.loading_refresh, args=())
+		self.loading_thread.name = "loading"
 		self.loading_thread.daemon = True # thread dies with the program
 		self.loading_thread.start()
 
@@ -1772,6 +1774,7 @@ class zynthian_gui:
 
 	def start_status_thread(self):
 		self.status_thread=Thread(target=self.status_thread_task, args=())
+		self.status_thread.name = "status"
 		self.status_thread.daemon = True # thread dies with the program
 		self.status_thread.start()
 


### PR DESCRIPTION
It looks like the problem with Zynthian crashing when closing down was that the JACK client was still active, so deactivate it when shutting down the autoconnector.