### PR TITLE
Read get_throttled from sysfs

### DIFF
--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -190,6 +190,8 @@ class zynthian_gui:
 		self.zynautoconnect_audio_flag = False
 		self.zynautoconnect_midi_flag = False
 
+		self.get_throttled_file = None
+
 		# Create Lock object to avoid concurrence problems
 		self.lock = Lock()
 
@@ -1606,9 +1608,10 @@ class zynthian_gui:
 				self.status_info['undervoltage'] = False
 				self.status_info['overtemp'] = False
 				try:
-					# Get ARM flags
-					res = check_output(("vcgencmd", "get_throttled")).decode('utf-8','ignore')
-					thr = int(res[12:],16)
+					if not self.get_throttled_file:
+						self.get_throttled_file = open('/sys/devices/platform/soc/soc:firmware/get_throttled')
+					self.get_throttled_file.seek(0)
+					thr = int('0x%s' % self.get_throttled_file.read(), 16)
 					if thr & 0x1:
 						self.status_info['undervoltage'] = True
 					elif thr & (0x4 | 0x2):


### PR DESCRIPTION
This avoids calling vcgencmd, which causes XRUNs in some environments.

Fixes #412