### PR TITLE
Fixes issue 638.

### DIFF
--- a/zyngine/zynthian_layer.py
+++ b/zyngine/zynthian_layer.py
@@ -258,6 +258,8 @@ class zynthian_layer:
 
 			preset_id = str(self.preset_list[i][0])
 			preset_name = self.preset_list[i][2]
+			if not preset_name:
+				return False
 			if preset_name[0]=='❤':
 				preset_name=preset_name[1:]
 

--- a/zyngui/zynthian_gui_layer.py
+++ b/zyngui/zynthian_gui_layer.py
@@ -369,7 +369,7 @@ class zynthian_gui_layer(zynthian_gui_selector):
 					self.layer_control(layer)
 				except Exception as e:
 					logging.error(e)
-					self.zyngui.show_screen('audio_mixer', hmode=SCREEN_HMODE_RESET)
+# SCREEN_HMODE_RESET is not in scope					self.zyngui.show_screen('audio_mixer', hmode=SCREEN_HMODE_RESET)
 
 
 	def remove_layer(self, i, stop_unused_engines=True):


### PR DESCRIPTION
Check if preset name exists before using it.
Do not return to mixer on error - which was using out-of-scope constant.