### PR TITLE
Feature/mixer midi learn

### DIFF
--- a/test/missing_test_navigation.sh
+++ b/test/missing_test_navigation.sh
@@ -1,0 +1,8 @@
+# Report missing navigation tests
+for x in {B..I}
+do
+    for y in {2..40}
+    do
+        [ `grep -c "#Test $x$y" /zynthian/zynthian-ui/test/test_navigation.py` -eq 1 ] || echo $x$y
+    done
+done

--- a/test/test_navigation.py
+++ b/test/test_navigation.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#******************************************************************************
+# ZYNTHIAN PROJECT: Zynthian GUI
+#
+# Zynthian GUI Navigation tests
+#
+# Copyright (C) 2022 Brian Walton <brian@riban.co.uk>
+#
+#******************************************************************************
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of
+# the License, or any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# For a full copy of the GNU General Public License see the LICENSE.txt file.
+#
+#******************************************************************************
+#
+# This tests navigation using OSC control, reading journal output
+# Zynthian must be running as a service
+#
+#******************************************************************************
+
+import liblo
+import pexpect
+
+zynthian_addr = 'localhost'
+
+#   Send a CUIA command via OSC
+#   cmd: OSC path for CUIA command, e.g. /cuia/reboot
+#   params: Optional parameters to send via OSC
+def cuia(cmd, params=None):
+    liblo.send('osc.udp://{}:1370'.format(zynthian_addr), cmd, params)
+
+
+#   Flush journal buffer
+def flush():
+    try:
+        journal.timeout = 0.1
+        journal.readlines()
+    except:
+        pass
+
+
+
+#   Run a test
+#   title: Title of test
+#   cmd: CUIA command to send to Zynthian
+#   params: CUIA parameters, may be None
+#   response: Expected response to be logged to journal
+#   timeout: Time to wait for response before signalling test failed
+#   Returns: True if test succeeds
+def test(title, cmd, params, response, timeout=1):
+    result = "FAILED"
+    flush()
+    cuia(cmd, params)
+    try:
+        journal.expect(response, timeout=timeout)
+        result = "PASSED"
+    except pexpect.TIMEOUT:
+        result = "FAILED"
+    except Exception as e:
+        print(e)
+    flush()
+    print("{}: {}".format(result, title))
+    return result
+
+#confirm('Start Zynthian regression testing?')
+journal = pexpect.spawn('/bin/journalctl -fu zynthian', encoding='UTF-8')
+
+test('Enable test mode', '/cuia/test_mode', 1, 'TEST_MODE: \[1\]\r\n')
+
+# Show mixer then clean so we know where we are starting from
+if test('Navigate to mixer view', '/cuia/SCREEN_AUDIO_MIXER', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n') == 'FAILED':
+    # May have toggled so let's try to recover
+    cuia('/cuia/SCREEN_AUDIO_MIXER')
+    flush()
+
+test('Clean all', '/cuia/clean_all', 'CONFIRM', 'TEST_MODE: zyngui.zynthian_gui_main\r\n', 10)
+
+test('Bold back should go to mixer view', '/cuia/switch_back_bold', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')

--- a/test/test_navigation.py
+++ b/test/test_navigation.py
@@ -82,44 +82,61 @@ test('Navigate to mixer view', '/cuia/show_view', 'audio_mixer', 'TEST_MODE: zyn
 
 test('Clean all', '/cuia/clean_all', 'CONFIRM', 'TEST_MODE: zyngui.zynthian_gui_main\r\n', 10)
 
-test('Main menu: select "New Synth Chain"', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_engine\r\n')
+#Test E10
+test('Main menu: short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_engine\r\n')
 
+#Test E11
 cuia('/cuia/arrow_down')
-test('Engine: Select FluidSynth', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_midi_chan\r\n')
+test('Engine: short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_midi_chan\r\n')
 
-test('Select MIDI channel', '/cuia/switch_select_short' , None, 'TEST_MODE: zyngui.zynthian_gui_bank\r\n')
+#Test E12
+test('MIDI channel: short select', '/cuia/switch_select_short' , None, 'TEST_MODE: zyngui.zynthian_gui_bank\r\n')
 
+#Test E13
 cuia('/cuia/arrow_down')
-test('Select Bank', '/cuia/switch_select_short' , None, 'TEST_MODE: zyngui.zynthian_gui_preset\r\n')
+test('Bank: short select', '/cuia/switch_select_short' , None, 'TEST_MODE: zyngui.zynthian_gui_preset\r\n')
 
-test('Select Preset', '/cuia/switch_select_short' , None, 'TEST_MODE: zyngui.zynthian_gui_control\r\n', 5)
+#Test E14
+test('Preset: short select', '/cuia/switch_select_short' , None, 'TEST_MODE: zyngui.zynthian_gui_control\r\n', 5)
 
-test('Control bold back', '/cuia/switch_back_bold', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
+#Test G5
+test('Control: bold back', '/cuia/switch_back_bold', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
 
-test('Mixer short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_control\r\n')
+#Test E2
+test('Mixer: short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_control\r\n')
 
+#Test F2
 cuia('/cuia/show_view', 'audio_mixer')
-test('Mixer bold layer', '/cuia/switch_layer_bold', None, 'TEST_MODE: zyngui.zynthian_gui_main\r\n')
+test('Mixer: bold layer', '/cuia/switch_layer_bold', None, 'TEST_MODE: zyngui.zynthian_gui_main\r\n')
 
+#Test H2
 cuia('/cuia/show_view', 'audio_mixer')
-test('Mixer bold snap/learn', '/cuia/switch_snapshot_bold', None, 'TEST_MODE: zyngui.zynthian_gui_snapshot\r\n')
+test('Mixer: bold snap/learn', '/cuia/switch_snapshot_bold', None, 'TEST_MODE: zyngui.zynthian_gui_snapshot\r\n')
 
+#Test I2
 cuia('/cuia/show_view', 'audio_mixer')
-test('Mixer bold select', '/cuia/switch_select_bold', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
+test('Mixer: bold select', '/cuia/switch_select_bold', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
 
-test('Chain options short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
+#Test C8
+test('Chain options: short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
 
+#Test E8
 cuia('/cuia/switch_select_bold')
-test('Chain options short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_midi_key_range\r\n')
+test('Chain options: short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_midi_key_range\r\n')
 
-test('MIDI key range short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
+#Test C9
+test('MIDI key range: short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
 
-test('Chain options bold select', '/cuia/switch_select_bold', None, 'TEST_MODE: zyngui.zynthian_gui_midi_key_range\r\n')
+#Test I8
+test('Chain options: bold select', '/cuia/switch_select_bold', None, 'TEST_MODE: zyngui.zynthian_gui_midi_key_range\r\n')
 
-test('MIDI key range short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
+#Test E9
+test('MIDI key range: short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
 
+#Test I9
 cuia('/cuia/switch_select_short')
-test('MIDI key range bold select', '/cuia/switch_select_bold', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
+test('MIDI key range: bold select', '/cuia/switch_select_bold', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
 
+#Test G8
 cuia('/cuia/switch_select_short')
-test('Chain options bold back', '/cuia/switch_back_bold', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
+test('Chain options: bold back', '/cuia/switch_back_bold', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')

--- a/test/test_navigation.py
+++ b/test/test_navigation.py
@@ -70,73 +70,119 @@ def test(title, cmd, params, response, timeout=1):
         print(e)
     flush()
     print("{}: {}".format(result, title))
-    return result
+    return result == "PASSED"
 
-#confirm('Start Zynthian regression testing?')
+overall_result = True
 journal = pexpect.spawn('/bin/journalctl -fu zynthian', encoding='UTF-8')
 
-test('Enable test mode', '/cuia/test_mode', 1, 'TEST_MODE: \[1\]\r\n')
+overall_result &= test('Enable test mode', '/cuia/test_mode', 1, 'TEST_MODE: \[1\]\r\n')
 
 # Show mixer then clean so we know where we are starting from
-test('Navigate to mixer view', '/cuia/show_view', 'audio_mixer', 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
+cuia('/cuia/show_view', 'audio_mixer')
 
-test('Clean all', '/cuia/clean_all', 'CONFIRM', 'TEST_MODE: zyngui.zynthian_gui_main\r\n', 10)
+overall_result &= test('Clean all', '/cuia/clean_all', 'CONFIRM', 'TEST_MODE: zyngui.zynthian_gui_main\r\n', 10)
 
 #Test E10
-test('Main menu: short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_engine\r\n')
+overall_result &= test('Main menu: short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_engine\r\n')
 
 #Test E11
 cuia('/cuia/arrow_down')
-test('Engine: short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_midi_chan\r\n')
+overall_result &= test('Engine: short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_midi_chan\r\n')
 
 #Test E12
-test('MIDI channel: short select', '/cuia/switch_select_short' , None, 'TEST_MODE: zyngui.zynthian_gui_bank\r\n')
+overall_result &= test('MIDI channel: short select', '/cuia/switch_select_short' , None, 'TEST_MODE: zyngui.zynthian_gui_bank\r\n')
 
 #Test E13
 cuia('/cuia/arrow_down')
-test('Bank: short select', '/cuia/switch_select_short' , None, 'TEST_MODE: zyngui.zynthian_gui_preset\r\n')
+overall_result &= test('Bank: short select', '/cuia/switch_select_short' , None, 'TEST_MODE: zyngui.zynthian_gui_preset\r\n')
 
 #Test E14
-test('Preset: short select', '/cuia/switch_select_short' , None, 'TEST_MODE: zyngui.zynthian_gui_control\r\n', 5)
+overall_result &= test('Preset: short select', '/cuia/switch_select_short' , None, 'TEST_MODE: zyngui.zynthian_gui_control\r\n', 5)
 
 #Test G5
-test('Control: bold back', '/cuia/switch_back_bold', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
+overall_result &= test('Control: bold back', '/cuia/switch_back_bold', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
 
 #Test E2
-test('Mixer: short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_control\r\n')
+overall_result &= test('Mixer: short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_control\r\n')
 
 #Test F2
 cuia('/cuia/show_view', 'audio_mixer')
-test('Mixer: bold layer', '/cuia/switch_layer_bold', None, 'TEST_MODE: zyngui.zynthian_gui_main\r\n')
+overall_result &= test('Mixer: bold layer', '/cuia/switch_layer_bold', None, 'TEST_MODE: zyngui.zynthian_gui_main\r\n')
 
 #Test H2
 cuia('/cuia/show_view', 'audio_mixer')
-test('Mixer: bold snap/learn', '/cuia/switch_snapshot_bold', None, 'TEST_MODE: zyngui.zynthian_gui_snapshot\r\n')
+overall_result &= test('Mixer: bold snap/learn', '/cuia/switch_snapshot_bold', None, 'TEST_MODE: zyngui.zynthian_gui_snapshot\r\n')
 
 #Test I2
 cuia('/cuia/show_view', 'audio_mixer')
-test('Mixer: bold select', '/cuia/switch_select_bold', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
+overall_result &= test('Mixer: bold select', '/cuia/switch_select_bold', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
 
 #Test C8
-test('Chain options: short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
+overall_result &= test('Chain options: short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
 
 #Test E8
 cuia('/cuia/switch_select_bold')
-test('Chain options: short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_midi_key_range\r\n')
+overall_result &= test('Chain options: short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_midi_key_range\r\n')
 
 #Test C9
-test('MIDI key range: short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
+overall_result &= test('MIDI key range: short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
 
 #Test I8
-test('Chain options: bold select', '/cuia/switch_select_bold', None, 'TEST_MODE: zyngui.zynthian_gui_midi_key_range\r\n')
+overall_result &= test('Chain options: bold select', '/cuia/switch_select_bold', None, 'TEST_MODE: zyngui.zynthian_gui_midi_key_range\r\n')
 
 #Test E9
-test('MIDI key range: short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
+overall_result &= test('MIDI key range: short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
 
 #Test I9
 cuia('/cuia/switch_select_short')
-test('MIDI key range: bold select', '/cuia/switch_select_bold', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
+overall_result &= test('MIDI key range: bold select', '/cuia/switch_select_bold', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
 
 #Test G8
 cuia('/cuia/switch_select_short')
-test('Chain options: bold back', '/cuia/switch_back_bold', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
+overall_result &= test('Chain options: bold back', '/cuia/switch_back_bold', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
+
+#Test C5
+cuia('/cuia/show_view', 'control')
+overall_result &= test('Control: short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_preset')
+
+#Test C10
+cuia('/cuia/show_view', 'control')
+cuia('/cuia/toggle_view', 'main')
+overall_result &= test('Main menu: short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_control')
+
+#Test C11
+cuia('/cuia/toggle_view', 'engine')
+overall_result &= test('Engine: short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_control')
+
+#Test C12
+cuia('/cuia/toggle_view', 'midi_chan')
+overall_result &= test('MIDI channel: short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_control')
+
+#Test C13
+cuia('/cuia/toggle_view', 'bank')
+overall_result &= test('Bank: short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_control')
+
+#Test C14
+cuia('/cuia/toggle_view', 'preset')
+overall_result &= test('Preset: short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_bank')
+
+#Test C17
+cuia('/cuia/toggle_view', 'preset')
+cuia('/cuia/switch_bold_select')
+overall_result &= test('Preset options: short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_preset')
+
+#Test C20
+cuia('/cuia/show_view', 'control')
+cuia('/cuia/toggle_view', 'admin')
+overall_result &= test('Preset: short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_control')
+
+#Test C40
+cuia('/cuia/show_view', 'control')
+cuia('/cuia/switch_bold_snapshot')
+overall_result &= test('Snapshot: short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_control')
+
+
+if overall_result:
+    print("All tests passed")
+else:
+    print("SOME TESTS FAILED!")

--- a/test/test_navigation.py
+++ b/test/test_navigation.py
@@ -78,11 +78,48 @@ journal = pexpect.spawn('/bin/journalctl -fu zynthian', encoding='UTF-8')
 test('Enable test mode', '/cuia/test_mode', 1, 'TEST_MODE: \[1\]\r\n')
 
 # Show mixer then clean so we know where we are starting from
-if test('Navigate to mixer view', '/cuia/SCREEN_AUDIO_MIXER', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n') == 'FAILED':
-    # May have toggled so let's try to recover
-    cuia('/cuia/SCREEN_AUDIO_MIXER')
-    flush()
+test('Navigate to mixer view', '/cuia/show_view', 'audio_mixer', 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
 
 test('Clean all', '/cuia/clean_all', 'CONFIRM', 'TEST_MODE: zyngui.zynthian_gui_main\r\n', 10)
 
-test('Bold back should go to mixer view', '/cuia/switch_back_bold', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
+test('Main menu: select "New Synth Chain"', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_engine\r\n')
+
+cuia('/cuia/arrow_down')
+test('Engine: Select FluidSynth', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_midi_chan\r\n')
+
+test('Select MIDI channel', '/cuia/switch_select_short' , None, 'TEST_MODE: zyngui.zynthian_gui_bank\r\n')
+
+cuia('/cuia/arrow_down')
+test('Select Bank', '/cuia/switch_select_short' , None, 'TEST_MODE: zyngui.zynthian_gui_preset\r\n')
+
+test('Select Preset', '/cuia/switch_select_short' , None, 'TEST_MODE: zyngui.zynthian_gui_control\r\n', 5)
+
+test('Control bold back', '/cuia/switch_back_bold', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
+
+test('Mixer short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_control\r\n')
+
+cuia('/cuia/show_view', 'audio_mixer')
+test('Mixer bold layer', '/cuia/switch_layer_bold', None, 'TEST_MODE: zyngui.zynthian_gui_main\r\n')
+
+cuia('/cuia/show_view', 'audio_mixer')
+test('Mixer bold snap/learn', '/cuia/switch_snapshot_bold', None, 'TEST_MODE: zyngui.zynthian_gui_snapshot\r\n')
+
+cuia('/cuia/show_view', 'audio_mixer')
+test('Mixer bold select', '/cuia/switch_select_bold', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
+
+test('Chain options short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')
+
+cuia('/cuia/switch_select_bold')
+test('Chain options short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_midi_key_range\r\n')
+
+test('MIDI key range short back', '/cuia/switch_back_short', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
+
+test('Chain options bold select', '/cuia/switch_select_bold', None, 'TEST_MODE: zyngui.zynthian_gui_midi_key_range\r\n')
+
+test('MIDI key range short select', '/cuia/switch_select_short', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
+
+cuia('/cuia/switch_select_short')
+test('MIDI key range bold select', '/cuia/switch_select_bold', None, 'TEST_MODE: zyngui.zynthian_gui_layer_options\r\n')
+
+cuia('/cuia/switch_select_short')
+test('Chain options bold back', '/cuia/switch_back_bold', None, 'TEST_MODE: zyngui.zynthian_gui_mixer\r\n')

--- a/zyngine/zynthian_controller.py
+++ b/zyngine/zynthian_controller.py
@@ -153,9 +153,6 @@ class zynthian_controller:
 
 		#Common configuration
 		self.value_range = self.value_max - self.value_min
-		if self.value_range == 0:
-			self.value_range = 1 # Avoid divide by zero errors
-			logging.warning("Controller %s calculated range is zero!", self.symbol)
 
 		if self.is_integer:
 			self.value_mid = self.value_min + int(self.value_range / 2)
@@ -271,7 +268,7 @@ class zynthian_controller:
 			if index < 0: index = 0
 			if index >= len(self.ticks) : index = len(self.ticks) - 1
 			self.set_value(self.ticks[index], send)
-		elif self.is_logarithmic:
+		elif self.is_logarithmic and self.value_range:
 			log_val = math.log10((9 * self.value - (10 * self.value_min - self.value_max)) / self.value_range)
 			log_val = min(1, max(0, log_val + val * self.nudge_factor))
 			self.set_value((math.pow(10, log_val) * self.value_range + (10 * self.value_min - self.value_max)) / 9)
@@ -399,7 +396,9 @@ class zynthian_controller:
 
 	def get_ctrl_midi_val(self):
 		try:
-			if self.is_logarithmic:
+			if self.value_range == 0:
+				return 0
+			elif self.is_logarithmic:
 				val = int(127 * math.log10((9 * self.value - (10 * self.value_min - self.value_max)) / self.value_range))
 			else:
 				val = min(127, int(127 * (self.value - self.value_min) / self.value_range))

--- a/zyngine/zynthian_controller.py
+++ b/zyngine/zynthian_controller.py
@@ -286,10 +286,13 @@ class zynthian_controller:
 			return
 
 		elif self.is_toggle:
-			if val==self.value_min or val==self.value_max:
-				self.value = val
+			if val == self.value_min or val == self.value_max:
+				if self.is_integer:
+					self.value = int(val)
+				else:
+					self.value = val
 			else:
-				if val<self.value_mid:
+				if val < self.value_mid:
 					self.value = self.value_min
 				else:
 					self.value = self.value_max

--- a/zyngine/zynthian_controller.py
+++ b/zyngine/zynthian_controller.py
@@ -585,7 +585,6 @@ class zynthian_controller:
 	#--------------------------------------------------------------------------
 
 
-	#TODO: riban recommends removing naitive zyncoder MIDI/OSC to match MVC model
 	def midi_learn_zyncoder(self, chan, cc):
 		try:
 			if lib_zyncore.set_midi_filter_cc_swap(ctypes.c_ubyte(chan), ctypes.c_ubyte(cc), ctypes.c_ubyte(self.midi_chan), ctypes.c_ubyte(self.midi_cc)):

--- a/zyngine/zynthian_engine_audioplayer.py
+++ b/zyngine/zynthian_engine_audioplayer.py
@@ -55,7 +55,17 @@ class zynthian_engine_audioplayer(zynthian_engine):
 		self.start()
 
 		# MIDI Controllers
-		self._ctrls=[]
+		self._ctrls=[
+			['gain', None, 1.0, 2.0],
+			['record', None, 'stopped', ['stopped', 'recording']],
+			['loop', None, 'one-shot', ['one-shot', 'looping']],
+			['transport', None, 'stopped', ['stopped', 'playing']],
+			['position', None, 0.0, 0.0],
+			['left track', None, 0, [['mixdown'], [0]]],
+			['right track', None, 0, [['mixdown'], [0]]],
+			['loop start', None, 0.0, 0.0],
+			['loop end', None, 0.0, 0.0]
+		]		
 
 		# Controller Screens
 		self._ctrl_screens =[]

--- a/zyngine/zynthian_engine_audioplayer.py
+++ b/zyngine/zynthian_engine_audioplayer.py
@@ -51,14 +51,6 @@ class zynthian_engine_audioplayer(zynthian_engine):
 		self.type = "MIDI Synth" # TODO: Should we override this? With what value?
 		self.file_exts = ["wav","WAV","ogg","OGG","flac","FLAC"]
 
-		self.options['clone'] = False
-		self.options['note_range'] = False
-		self.options['audio_route'] = True
-		self.options['midi_chan'] = True
-		self.options['replace'] = True
-		self.options['drop_pc'] = True
-		self.options['layer_audio_out'] = True
-
 		self.custom_gui_fpath = "/zynthian/zynthian-ui/zyngui/zynthian_widget_audioplayer.py"
 		self.start()
 

--- a/zyngine/zynthian_engine_audioplayer.py
+++ b/zyngine/zynthian_engine_audioplayer.py
@@ -27,7 +27,6 @@ from collections import OrderedDict
 import logging
 from glob import glob
 from . import zynthian_engine
-from . import zynthian_controller
 from zynlibs.zynaudioplayer import zynaudioplayer
 
 #------------------------------------------------------------------------------

--- a/zyngine/zynthian_engine_audioplayer.py
+++ b/zyngine/zynthian_engine_audioplayer.py
@@ -94,7 +94,7 @@ class zynthian_engine_audioplayer(zynthian_engine):
 
 	def stop(self):
 		try:
-			self.player.remove_player()
+			self.player = None
 		except Exception as e:
 			logging.error("Failed to close audio player: %s", e)
 

--- a/zyngui/zynthian_audio_recorder.py
+++ b/zyngui/zynthian_audio_recorder.py
@@ -6,7 +6,7 @@
 # Zynthian Audio Recorder Class
 # 
 # Copyright (C) 2015-2022 Fernando Moyano <jofemodo@zynthian.org>
-# Copyright (C) 2022 Brian Walton <riban@zynthian.org>
+#                         Brian Walton <riban@zynthian.org>
 #
 #******************************************************************************
 # 

--- a/zyngui/zynthian_gui_admin.py
+++ b/zyngui/zynthian_gui_admin.py
@@ -90,6 +90,11 @@ class zynthian_gui_admin(zynthian_gui_selector):
 		else:
 			self.list_data.append((self.toggle_preset_preload_noteon,0,"[  ] Preset Preload"))
 
+		if zynthian_gui_config.enable_dpm:
+			self.list_data.append((self.toggle_dpm,0,"[x] Mixer Peak Meters"))
+		else:
+			self.list_data.append((self.toggle_dpm,0,"[  ] Mixer Peak Meters"))
+
 		if zynthian_gui_config.snapshot_mixer_settings:
 			self.list_data.append((self.toggle_snapshot_mixer_settings,0,"[x] Audio Levels on Snapshots"))
 		else:
@@ -321,6 +326,11 @@ class zynthian_gui_admin(zynthian_gui_selector):
 			self.start_rbpi_headphones(False)
 		else:
 			self.stop_rbpi_headphones(False)
+
+
+	def toggle_dpm(self):
+		zynthian_gui_config.enable_dpm = not zynthian_gui_config.enable_dpm
+		self.fill_list()
 
 
 	def toggle_snapshot_mixer_settings(self):

--- a/zyngui/zynthian_gui_arranger.py
+++ b/zyngui/zynthian_gui_arranger.py
@@ -350,6 +350,8 @@ class zynthian_gui_arranger():
 	# Function to show GUI
 	#	params: Optional dictionary of configuration, e.g. "sequence":number
 	def show(self, params={}):
+		if self.zyngui.test_mode:
+			logging.warning("TEST_MODE: {}".format(self.__class__.__module__))
 		self.main_frame.tkraise()
 		self.select_bank()
 		self.setup_encoders()

--- a/zyngui/zynthian_gui_audio_out.py
+++ b/zyngui/zynthian_gui_audio_out.py
@@ -5,7 +5,7 @@
 # 
 # Zynthian GUI Audio-Out Selector Class
 # 
-# Copyright (C) 2015-2018 Fernando Moyano <jofemodo@zynthian.org>
+# Copyright (C) 2015-2022 Fernando Moyano <jofemodo@zynthian.org>
 #
 #******************************************************************************
 # 
@@ -48,10 +48,6 @@ class zynthian_gui_audio_out(zynthian_gui_selector):
 			self.end_layer = self.zyngui.screens['layer'].get_fxchain_ends(layer)[0]
 		except:
 			self.end_layer = None
-
-
-	def set_audio_player(self):
-		self.end_layer = self.zyngui.screens['audio_recorder']
 
 
 	def fill_list(self):

--- a/zyngui/zynthian_gui_autoeq.py
+++ b/zyngui/zynthian_gui_autoeq.py
@@ -5,7 +5,7 @@
 # 
 # Zynthian GUI Auto-EQ Class
 # 
-# Copyright (C) 2015-2020 Fernando Moyano <jofemodo@zynthian.org>
+# Copyright (C) 2015-2022 Fernando Moyano <jofemodo@zynthian.org>
 #
 #******************************************************************************
 # 
@@ -93,6 +93,8 @@ class zynthian_gui_autoeq():
 
 	def show(self):
 		if not self.shown:
+			if self.zyngui.test_mode:
+				logging.warning("TEST_MODE: {}".format(self.__class__.__module__))
 			self.shown=True
 			self.main_frame.grid()
 

--- a/zyngui/zynthian_gui_base.py
+++ b/zyngui/zynthian_gui_base.py
@@ -550,44 +550,6 @@ class zynthian_gui_base:
 		pass
 
 
-	def select_up(self):
-		self.zynpot_cb(zynthian_gui_config.ENC_SELECT, 1)
-
-
-	# Function to handle CUIA SELECT_DOWN command
-	def select_down(self):
-		self.zynpot_cb(zynthian_gui_config.ENC_SELECT, -1)
-
-
-	# Function to handle CUIA BACK_UP command
-	def back_up(self):
-		self.zynpot_cb(zynthian_gui_config.ENC_BACK, 1)
-
-
-	# Function to handle CUIA BACK_DOWN command
-	def back_down(self):
-		self.zynpot_cb(zynthian_gui_config.ENC_BACK, -1)
-
-
-	# Function to handle CUIA LAYER_UP command
-	def layer_up(self):
-		self.zynpot_cb(zynthian_gui_config.ENC_LAYER, 1)
-
-
-	# Function to handle CUIA LAYER_DOWN command
-	def layer_down(self):
-		self.zynpot_cb(zynthian_gui_config.ENC_LAYER, -1)
-
-
-	# Function to handle CUIA SNAPSHOT_UP command
-	def snapshot_up(self):
-		self.zynpot_cb(zynthian_gui_config.ENC_SNAPSHOT, 1)
-
-
-	# Function to handle CUIA SNAPSHOT_DOWN command
-	def snapshot_down(self):
-		self.zynpot_cb(zynthian_gui_config.ENC_SNAPSHOT, -1)
-
 	#--------------------------------------------------------------------------
 	# Keyboard & Mouse/Touch Callbacks
 	#--------------------------------------------------------------------------

--- a/zyngui/zynthian_gui_base.py
+++ b/zyngui/zynthian_gui_base.py
@@ -551,14 +551,13 @@ class zynthian_gui_base:
 		pass
 
 
-	# Function to handle CUIA SELECT_UP command (reversed to drive down screen with DOWN action)
 	def select_up(self):
-		self.zynpot_cb(zynthian_gui_config.ENC_SELECT, -1)
+		self.zynpot_cb(zynthian_gui_config.ENC_SELECT, 1)
 
 
 	# Function to handle CUIA SELECT_DOWN command
 	def select_down(self):
-		self.zynpot_cb(zynthian_gui_config.ENC_SELECT, 1)
+		self.zynpot_cb(zynthian_gui_config.ENC_SELECT, -1)
 
 
 	# Function to handle CUIA BACK_UP command

--- a/zyngui/zynthian_gui_base.py
+++ b/zyngui/zynthian_gui_base.py
@@ -234,7 +234,8 @@ class zynthian_gui_base:
 		for i in range(4):
 			self.buttonbar_frame.grid_columnconfigure(
 				i, minsize=zynthian_gui_config.button_width, pad=0)
-			self.add_button(i, self.buttonbar_config[i][0], self.buttonbar_config[i][1])
+			if self.buttonbar_config[i]:
+				self.add_button(i, self.buttonbar_config[i][0], self.buttonbar_config[i][1])
 
 
 	def set_buttonbar_label(self, column, label):

--- a/zyngui/zynthian_gui_base.py
+++ b/zyngui/zynthian_gui_base.py
@@ -310,6 +310,8 @@ class zynthian_gui_base:
 
 	def show(self):
 		if not self.shown:
+			if self.zyngui.test_mode:
+				logging.warning("TEST_MODE: {}".format(self.__class__.__module__))
 			self.shown=True
 			self.main_frame.grid()
 
@@ -439,9 +441,6 @@ class zynthian_gui_base:
 
 				except Exception as e:
 					logging.error("%s" % e)
-
-			#status['xrun']=True
-			#status['audio_recorder']='PLAY'
 
 			# Display error flags
 			flags = ""

--- a/zyngui/zynthian_gui_config.py
+++ b/zyngui/zynthian_gui_config.py
@@ -402,6 +402,7 @@ multichannel_recorder=int(os.environ.get('ZYNTHIAN_UI_MUKTICHANNEL_REC', 0))
 #------------------------------------------------------------------------------
 
 rbpi_headphones=int(os.environ.get('ZYNTHIAN_RBPI_HEADPHONES',False))
+enable_dpm=int(os.environ.get('ZYNTHIAN_DPM',True))
 
 #------------------------------------------------------------------------------
 # Networking Options

--- a/zyngui/zynthian_gui_confirm.py
+++ b/zyngui/zynthian_gui_confirm.py
@@ -5,7 +5,7 @@
 # 
 # Zynthian GUI Confirm Class
 # 
-# Copyright (C) 2018 Markus Heidt <markus@heidt-tech.com>
+# Copyright (C) 2022 Markus Heidt <markus@heidt-tech.com>
 #                    Fernando Moyano <jofemodo@zynthian.org>
 #
 #******************************************************************************
@@ -93,6 +93,8 @@ class zynthian_gui_confirm():
 
 
 	def show(self, text, callback=None, cb_params=None):
+		if self.zyngui.test_mode:
+			logging.warning("TEST_MODE: {}".format(self.__class__.__module__))
 		self.text.set(text)
 		self.callback = callback
 		self.callback_params = cb_params

--- a/zyngui/zynthian_gui_confirm.py
+++ b/zyngui/zynthian_gui_confirm.py
@@ -116,6 +116,11 @@ class zynthian_gui_confirm():
 			self.callback(self.callback_params)
 
 
+	def switch(self, i, t):
+		if i in [0,2]:
+			return True
+
+
 	def cb_yes_push(self, event):
 		self.zyngui.zynswitch_defered('S',3)
 

--- a/zyngui/zynthian_gui_control.py
+++ b/zyngui/zynthian_gui_control.py
@@ -341,23 +341,6 @@ class zynthian_gui_control(zynthian_gui_selector):
 			return False
 
 
-	# Function to handle CUIA SELECT_UP command (reversed to drive down screen with DOWN action)
-	def select_up(self):
-		if self.mode == 'control':
-			self.zynpot_cb(zynthian_gui_config.ENC_SELECT, 1)
-		else:
-			self.zynpot_cb(zynthian_gui_config.ENC_SELECT, -1)
-
-
-	# Function to handle CUIA SELECT_DOWN command
-	def select_down(self):
-		if self.mode == 'control':
-			self.zynpot_cb(zynthian_gui_config.ENC_SELECT, -1)
-		else:
-			self.zynpot_cb(zynthian_gui_config.ENC_SELECT, 1)
-
-
-
 	def arrow_up(self):
 		i = self.index - 1
 		if i < 0:

--- a/zyngui/zynthian_gui_control.py
+++ b/zyngui/zynthian_gui_control.py
@@ -474,6 +474,11 @@ class zynthian_gui_control(zynthian_gui_selector):
 		return self.zgui_controllers[i]
 
 
+	def start_midi_learn(self):
+		self.refresh_midi_bind()
+		self.set_select_path()
+
+    	
 	def end_midi_learn(self):
 		self.refresh_midi_bind()
 		self.set_select_path()

--- a/zyngui/zynthian_gui_control.py
+++ b/zyngui/zynthian_gui_control.py
@@ -474,6 +474,11 @@ class zynthian_gui_control(zynthian_gui_selector):
 		return self.zgui_controllers[i]
 
 
+	def end_midi_learn(self):
+		self.refresh_midi_bind()
+		self.set_select_path()
+
+
 	def refresh_midi_bind(self):
 		learning = False
 		for zgui_controller in self.zgui_controllers:

--- a/zyngui/zynthian_gui_control_xy.py
+++ b/zyngui/zynthian_gui_control_xy.py
@@ -127,7 +127,9 @@ class zynthian_gui_control_xy():
 	def get_controller_values(self):
 		if self.x_zctrl.value != self.xvalue:
 			self.xvalue = self.x_zctrl.value
-			if self.x_zctrl.is_logarithmic:
+			if self.x_zctrl.value_range == 0:
+				self.x = 0
+			elif self.x_zctrl.is_logarithmic:
 				self.x = int(self.width * math.log10((9 * self.x_zctrl.value - (10 * self.x_zctrl.value_min - self.x_zctrl.value_max)) / self.x_zctrl.value_range))
 			else:
 				self.x = int(self.width * (self.xvalue - self.x_zctrl.value_min) / self.x_zctrl.value_range)
@@ -135,7 +137,9 @@ class zynthian_gui_control_xy():
 
 		if self.y_zctrl.value != self.yvalue:
 			self.yvalue = self.y_zctrl.value
-			if self.y_zctrl.is_logarithmic:
+			if self.y_zctrl.value_range == 0:
+				self.y = 0
+			elif self.y_zctrl.is_logarithmic:
 				self.y = int(self.width * math.log10((9 * self.y_zctrl.value - (10 * self.y_zctrl.value_min - self.y_zctrl.value_max)) / self.y_zctrl.value_range))
 			else:
 				self.y = int(self.height * (self.yvalue - self.y_zctrl.value_min) / self.y_zctrl.value_range)

--- a/zyngui/zynthian_gui_control_xy.py
+++ b/zyngui/zynthian_gui_control_xy.py
@@ -97,6 +97,8 @@ class zynthian_gui_control_xy():
 
 	def show(self):
 		if not self.shown:
+			if self.zyngui.test_mode:
+				logging.warning("TEST_MODE: {}".format(self.__class__.__module__))
 			self.shown= True
 			self.main_frame.grid()
 			self.refresh()

--- a/zyngui/zynthian_gui_controller.py
+++ b/zyngui/zynthian_gui_controller.py
@@ -180,7 +180,9 @@ class zynthian_gui_controller:
 				self.value_print="ERR"
 
 		else:
-			if self.zctrl.is_logarithmic:
+			if self.zctrl.value_range == 0:
+				self.value_plot = 0
+			elif self.zctrl.is_logarithmic:
 				self.value_plot = math.log10((9 * self.zctrl.value - (10 * self.zctrl.value_min - self.zctrl.value_max)) / self.zctrl.value_range)
 			else:
 				self.value_plot = (self.zctrl.value - self.zctrl.value_min) / self.zctrl.value_range
@@ -526,7 +528,10 @@ class zynthian_gui_controller:
 		#Numeric value
 		else:
 			#Integer
-			if zctrl.is_integer:
+			if zctrl.value_range == 0:
+				self.pixels_per_div = 1
+
+			elif zctrl.is_integer:
 				self.pixels_per_div = self.height // zctrl.value_range
 				# If few values => use fixed step=1 (no adaptative step size!)
 				if zctrl.value_range <= 32:

--- a/zyngui/zynthian_gui_info.py
+++ b/zyngui/zynthian_gui_info.py
@@ -5,7 +5,7 @@
 # 
 # Zynthian GUI Info Class
 # 
-# Copyright (C) 2015-2016 Fernando Moyano <jofemodo@zynthian.org>
+# Copyright (C) 2015-2022 Fernando Moyano <jofemodo@zynthian.org>
 #
 #******************************************************************************
 # 
@@ -89,6 +89,8 @@ class zynthian_gui_info:
 
 
 	def show(self, text):
+		if self.zyngui.test_mode:
+			logging.warning("TEST_MODE: {}".format(self.__class__.__module__))
 		self.set(text)
 		if not self.shown:
 			self.shown=True

--- a/zyngui/zynthian_gui_keyboard.py
+++ b/zyngui/zynthian_gui_keyboard.py
@@ -5,8 +5,8 @@
 # 
 # Zynthian GUI keyboard Class
 # 
-# Copyright (C) 2015-2020 Fernando Moyano <jofemodo@zynthian.org>
-# Copyright (C) 2020-2021 Brian Walton <brian@riban.co.uk>
+# Copyright (C) 2015-2022 Fernando Moyano <jofemodo@zynthian.org>
+#                         Brian Walton <brian@riban.co.uk>
 #
 #******************************************************************************
 # 
@@ -261,6 +261,8 @@ class zynthian_gui_keyboard():
 	#	text: Text to display (Default: empty)
 	#	max_len: Maximum quantity of characters in text (Default: no limit)
 	def show(self, function, text="", max_len=None):
+		if self.zyngui.test_mode:
+			logging.warning("TEST_MODE: {}".format(self.__class__.__module__))
 		self.function = function
 		self.text= text
 		if max_len:

--- a/zyngui/zynthian_gui_keyboard.py
+++ b/zyngui/zynthian_gui_keyboard.py
@@ -26,7 +26,6 @@
 
 import tkinter
 import logging
-import math
 import tkinter.font as tkFont
 from threading import Timer
 
@@ -37,11 +36,6 @@ from zyngui import zynthian_gui_config
 #------------------------------------------------------------------------------
 # Zynthian Onscreen Keyboard GUI Class
 #------------------------------------------------------------------------------
-
-ZYNPOT_LAYER		= 0
-ZYNPOT_BACK			= 1
-ZYNPOT_SNAPSHOT		= 2
-ZYNPOT_SELECT		= 3
 
 OSK_NUMPAD			= 0
 OSK_QWERTY			= 1
@@ -210,7 +204,7 @@ class zynthian_gui_keyboard():
 			self.function(self.text)
 			return
 		elif key == self.btn_cancel:
-			self.zyngui.zynswitch_defered('S', ZYNPOT_BACK)
+			self.zyngui.zynswitch_defered('S', zynthian_gui_config.ENC_BACK)
 			return
 		elif key == self.btn_delete:
 			if bold:
@@ -280,8 +274,8 @@ class zynthian_gui_keyboard():
 	# Function to register encoders
 	def setup_zynpots(self):
 		if lib_zyncore:
-			lib_zyncore.setup_behaviour_zynpot(ZYNPOT_SELECT, 1)
-			lib_zyncore.setup_behaviour_zynpot(ZYNPOT_BACK, 1)
+			lib_zyncore.setup_behaviour_zynpot(zynthian_gui_config.ENC_SELECT, 1)
+			lib_zyncore.setup_behaviour_zynpot(zynthian_gui_config.ENC_BACK, 1)
 
 
 	# Function to handle zynpots events
@@ -289,9 +283,9 @@ class zynthian_gui_keyboard():
 		if not self.shown:
 			return
 		if lib_zyncore:
-			if i == ZYNPOT_SELECT:
+			if i == zynthian_gui_config.ENC_SELECT:
 				self.cursor_hmove(dval)
-			elif i == ZYNPOT_BACK:
+			elif i == zynthian_gui_config.ENC_BACK:
 				self.cursor_vmove(dval)
 
 

--- a/zyngui/zynthian_gui_layer.py
+++ b/zyngui/zynthian_gui_layer.py
@@ -38,7 +38,6 @@ from zyncoder.zyncore import lib_zyncore
 from zyngine import zynthian_layer
 from zyngui import zynthian_gui_config
 from zyngui.zynthian_gui_selector import zynthian_gui_selector
-from zynlibs.zynmixer import *
 
 #------------------------------------------------------------------------------
 # Zynthian Layer Selection GUI Class
@@ -414,7 +413,7 @@ class zynthian_gui_layer(zynthian_gui_selector):
 			chans_to_reset = []
 			for root_layer in root_layers_to_delete:
 				chans_to_reset.append(root_layer.midi_chan)
-				zynmixer.set_mute(root_layer.midi_chan, True)
+				self.zyngui.zynmixer.set_mute(root_layer.midi_chan, True)
 				# Midichain layers
 				midichain_layers = self.get_midichain_layers(root_layer)
 				if len(midichain_layers)>0:
@@ -456,7 +455,7 @@ class zynthian_gui_layer(zynthian_gui_selector):
 				self.zyngui.screens['engine'].stop_unused_engines()
 
 			for chan in chans_to_reset:
-				zynmixer.reset(chan)
+				self.zyngui.zynmixer.reset(chan)
 
 			self.refresh()
 

--- a/zyngui/zynthian_gui_layer.py
+++ b/zyngui/zynthian_gui_layer.py
@@ -1190,7 +1190,7 @@ class zynthian_gui_layer(zynthian_gui_selector):
 				'midi_routing': self.get_midi_routing(),
 				'extended_config': self.get_extended_config(),
 				'midi_profile_state': self.get_midi_profile_state(),
-				'mixer':[]
+				'mixer': self.zyngui.zynmixer.get_state()
 			}
 
 			#Layers info
@@ -1232,12 +1232,6 @@ class zynthian_gui_layer(zynthian_gui_selector):
 				if self.zyngui.audio_recorder.is_primed(midi_chan):
 					snapshot['audio_recorder_primed'].append(midi_chan)
 
-			#Mixer
-			try:
-				snapshot['mixer'] = self.zyngui.screens['audio_mixer'].get_state()
-			except Exception as e:
-				pass
-
 			#JSON Encode
 			json=JSONEncoder().encode(snapshot)
 			logging.info("Saving snapshot %s => \n%s" % (fpath,json))
@@ -1276,8 +1270,8 @@ class zynthian_gui_layer(zynthian_gui_selector):
 				self._load_snapshot_sequences(snapshot)
 			#Mixer
 			try:
-				self.zyngui.screens['audio_mixer'].reset_state()
-				self.zyngui.screens['audio_mixer'].set_state(snapshot['mixer'])
+				self.zyngui.zynmixer.reset_state()
+				self.zyngui.zynmixer.set_state(snapshot['mixer'])
 			except Exception as e:
 				pass
 

--- a/zyngui/zynthian_gui_layer_options.py
+++ b/zyngui/zynthian_gui_layer_options.py
@@ -29,7 +29,6 @@ import logging
 # Zynthian specific modules
 from zyngui import zynthian_gui_config
 from zyngui.zynthian_gui_selector import zynthian_gui_selector
-from zynlibs.zynmixer import *
 
 #------------------------------------------------------------------------------
 # Zynthian Layer Options GUI Class
@@ -103,12 +102,12 @@ class zynthian_gui_layer_options(zynthian_gui_selector):
 			if 'clone' in eng_options and eng_options['clone'] and self.layer.midi_chan is not None:
 				self.list_data.append((self.layer_clone, None, "Clone MIDI to ..."))
 
-			if zynmixer.get_mono(self.layer.midi_chan):
+			if self.zyngui.zynmixer.get_mono(self.layer.midi_chan):
 				self.list_data.append((self.layer_toggle_mono, None, "[x] Audio Mono"))
 			else:
 				self.list_data.append((self.layer_toggle_mono, None, "[  ] Audio Mono"))
 
-			if zynmixer.get_phase(self.layer.midi_chan):
+			if self.zyngui.zynmixer.get_phase(self.layer.midi_chan):
 				self.list_data.append((self.layer_toggle_phase, None, "[x] Phase reverse B"))
 			else:
 				self.list_data.append((self.layer_toggle_phase, None, "[  ] Phase reverse B"))
@@ -347,12 +346,12 @@ class zynthian_gui_layer_options(zynthian_gui_selector):
 
 
 	def layer_toggle_mono(self):
-		zynmixer.toggle_mono(self.layer.midi_chan)
+		self.zyngui.zynmixer.toggle_mono(self.layer.midi_chan)
 		self.show()
 
 
 	def layer_toggle_phase(self):
-		zynmixer.toggle_phase(self.layer.midi_chan)
+		self.zyngui.zynmixer.toggle_phase(self.layer.midi_chan)
 		self.show()
 
 

--- a/zyngui/zynthian_gui_layer_options.py
+++ b/zyngui/zynthian_gui_layer_options.py
@@ -384,6 +384,7 @@ class zynthian_gui_layer_options(zynthian_gui_selector):
 
 	def layer_midi_unlearn_confirmed(self, params=None):
 		self.layer.midi_unlearn()
+		self.zyngui.zynmixer.midi_unlearn_chan(self.layer.midi_chan)
 
 
 	# FX-Chain management

--- a/zyngui/zynthian_gui_main.py
+++ b/zyngui/zynthian_gui_main.py
@@ -28,7 +28,6 @@ import logging
 # Zynthian specific modules
 from zyngui import zynthian_gui_config
 from zyngui.zynthian_gui_selector import zynthian_gui_selector
-from zynlibs.zynseq import zynseq
 
 #------------------------------------------------------------------------------
 # Zynthian App Selection GUI Class
@@ -101,14 +100,8 @@ class zynthian_gui_main(zynthian_gui_selector):
 
 
 	def clean_all_confirmed(self, params=None):
-		if len(self.zyngui.screens['layer'].layers) > 0:
-			self.zyngui.screens['snapshot'].save_last_state_snapshot()
-		self.zyngui.screens['layer'].reset()
-		self.zyngui.zynmixer.reset_state()
-		if zynseq.libseq:
-			zynseq.load("")
 		self.index = 0
-		self.zyngui.show_screen_reset('main')
+		self.zyngui.clean_all()
 
 
 	def audio_mixer(self, t='S'):

--- a/zyngui/zynthian_gui_main.py
+++ b/zyngui/zynthian_gui_main.py
@@ -101,10 +101,10 @@ class zynthian_gui_main(zynthian_gui_selector):
 
 
 	def clean_all_confirmed(self, params=None):
-		if len(self.zyngui.screens['layer'].layers)>0:
+		if len(self.zyngui.screens['layer'].layers) > 0:
 			self.zyngui.screens['snapshot'].save_last_state_snapshot()
 		self.zyngui.screens['layer'].reset()
-		self.zyngui.screens['audio_mixer'].reset_state()
+		self.zyngui.zynmixer.reset_state()
 		if zynseq.libseq:
 			zynseq.load("")
 		self.index = 0

--- a/zyngui/zynthian_gui_midi_key_range.py
+++ b/zyngui/zynthian_gui_midi_key_range.py
@@ -421,10 +421,10 @@ class zynthian_gui_midi_key_range(zynthian_gui_base):
 		for key,rect in enumerate(self.piano_keys):
 			if event.x < event.widget.coords(rect)[2]:
 				vis_key = self.midi_key0 + key
-				if vis_key > self.clicked_key and vis_key != self.nhigh_zctrl.value:
+				if vis_key >= self.clicked_key and vis_key != self.nhigh_zctrl.value:
 					self.nhigh_zctrl.set_value(vis_key)
 					self.update_piano()
-				elif vis_key < self.clicked_key and vis_key != self.nlow_zctrl.value:
+				elif vis_key <= self.clicked_key and vis_key != self.nlow_zctrl.value:
 					self.nlow_zctrl.set_value(vis_key)
 					self.update_piano()
 				return

--- a/zyngui/zynthian_gui_midi_key_range.py
+++ b/zyngui/zynthian_gui_midi_key_range.py
@@ -215,7 +215,7 @@ class zynthian_gui_midi_key_range(zynthian_gui_base):
 	def plot_text(self):
 		fs = int(1.7 * zynthian_gui_config.font_size)
 
-		self.nlow_text=self.note_info_canvas.create_text(
+		self.nlow_text = self.note_info_canvas.create_text(
 			int(zynthian_gui_config.ctrl_width / 2),
 			int((self.note_info_canvas_height-fs) / 1.5),
 			width=5 * fs,
@@ -223,8 +223,10 @@ class zynthian_gui_midi_key_range(zynthian_gui_base):
 			fill=zynthian_gui_config.color_ctrl_tx,
 			font=(zynthian_gui_config.font_family, fs),
 			text=self.get_midi_note_name(self.note_low))
+		self.note_info_canvas.tag_bind(self.nlow_text, "<Button-4>", self.cb_nlow_wheel_up)
+		self.note_info_canvas.tag_bind(self.nlow_text, "<Button-5>", self.cb_nlow_wheel_down)
 
-		self.nhigh_text=self.note_info_canvas.create_text(
+		self.nhigh_text = self.note_info_canvas.create_text(
 			self.piano_canvas_width - int(zynthian_gui_config.ctrl_width / 2),
 			int((self.note_info_canvas_height-fs) / 1.5),
 			width=5 * fs,
@@ -232,9 +234,11 @@ class zynthian_gui_midi_key_range(zynthian_gui_base):
 			fill=zynthian_gui_config.color_ctrl_tx,
 			font=(zynthian_gui_config.font_family, fs),
 			text=self.get_midi_note_name(self.note_high))
+		self.note_info_canvas.tag_bind(self.nhigh_text, "<Button-4>", self.cb_nhigh_wheel_up)
+		self.note_info_canvas.tag_bind(self.nhigh_text, "<Button-5>", self.cb_nhigh_wheel_down)
 
 
-		self.learn_text=self.note_info_canvas.create_text(
+		self.learn_text = self.note_info_canvas.create_text(
 			zynthian_gui_config.display_width  / 2,
 			int((self.note_info_canvas_height-fs) / 1.5),
 			width=5 * fs,
@@ -424,5 +428,21 @@ class zynthian_gui_midi_key_range(zynthian_gui_base):
 					self.nlow_zctrl.set_value(vis_key)
 					self.update_piano()
 				return
+
+
+	def cb_nlow_wheel_up(self, event):
+		self.nlow_zgui_ctrl.zynpot_cb(1)
+
+
+	def cb_nlow_wheel_down(self, event):
+		self.nlow_zgui_ctrl.zynpot_cb(-1)
+
+
+	def cb_nhigh_wheel_up(self, event):
+		self.nhigh_zgui_ctrl.zynpot_cb(1)
+
+
+	def cb_nhigh_wheel_down(self, event):
+		self.nhigh_zgui_ctrl.zynpot_cb(-1)
 
 #------------------------------------------------------------------------------

--- a/zyngui/zynthian_gui_midi_key_range.py
+++ b/zyngui/zynthian_gui_midi_key_range.py
@@ -5,7 +5,7 @@
 # 
 # Zynthian GUI MIDI key-range config class
 # 
-# Copyright (C) 2015-2020 Fernando Moyano <jofemodo@zynthian.org>
+# Copyright (C) 2015-2022 Fernando Moyano <jofemodo@zynthian.org>
 #
 #******************************************************************************
 # 
@@ -52,19 +52,18 @@ class zynthian_gui_midi_key_range(zynthian_gui_base):
 		self.octave_trans = 0
 		self.halftone_trans = 0
 
-		self.learn_toggle = 0
-		self.learn_mode = True
+		self.learn_mode = 0 # [0:Disabled, 1:Lower, 2:Upper]
 
-		self.nlow_zgui_ctrl=None
-		self.nhigh_zgui_ctrl=None
-		self.octave_zgui_ctrl=None
-		self.halftone_zgui_ctrl=None
+		self.nlow_zgui_ctrl = None
+		self.nhigh_zgui_ctrl = None
+		self.octave_zgui_ctrl = None
+		self.halftone_zgui_ctrl = None
 
 		if zynthian_gui_config.ctrl_both_sides:
-			self.space_frame_width = zynthian_gui_config.display_width-2*zynthian_gui_config.ctrl_width
+			self.space_frame_width = zynthian_gui_config.display_width - 2 * zynthian_gui_config.ctrl_width
 			self.space_frame_height = zynthian_gui_config.ctrl_height - 2
 			self.piano_canvas_width = zynthian_gui_config.display_width
-			self.piano_canvas_height = int(zynthian_gui_config.ctrl_height/2)
+			self.piano_canvas_height = int(zynthian_gui_config.ctrl_height / 2)
 			self.note_info_canvas_height = zynthian_gui_config.ctrl_height - self.piano_canvas_height
 			self.zctrl_pos = [0, 2, 1, 3]
 		else:
@@ -136,11 +135,11 @@ class zynthian_gui_midi_key_range(zynthian_gui_base):
 
 		i = 0
 		x1 = 0
-		x2 = key_width-1
+		x2 = key_width - 1
 		midi_note = self.midi_key0
-		while x1<self.piano_canvas_width:
+		while x1 < self.piano_canvas_width:
 			# plot white-key
-			if self.note_low>midi_note or self.note_high<midi_note:
+			if self.note_low > midi_note or self.note_high < midi_note:
 				bgcolor = "#D0D0D0"
 			else:
 				bgcolor = "#FFFFFF"
@@ -155,10 +154,10 @@ class zynthian_gui_midi_key_range(zynthian_gui_base):
 
 			# plot black key when needed ...
 			if self.black_keys_pattern[i % 7]:
-				x1b = x1-int(key_width/3)
-				x2b = x1b+int(2*key_width/3)
-				if x2b<self.piano_canvas_width:
-					if self.note_low>midi_note or self.note_high<midi_note:
+				x1b = x1 - int(key_width / 3)
+				x2b = x1b + int(2*key_width / 3)
+				if x2b < self.piano_canvas_width:
+					if self.note_low > midi_note or self.note_high < midi_note:
 						bgcolor = "#707070"
 					else:
 						bgcolor = "#000000"
@@ -174,8 +173,8 @@ class zynthian_gui_midi_key_range(zynthian_gui_base):
 		i = 0
 		j = 0
 		midi_note = self.midi_key0
-		while j<len(self.piano_keys):
-			if self.note_low>midi_note or self.note_high<midi_note:
+		while j < len(self.piano_keys):
+			if self.note_low > midi_note or self.note_high < midi_note:
 				bgcolor = "#D0D0D0"
 			else:
 				bgcolor = "#FFFFFF"
@@ -184,7 +183,7 @@ class zynthian_gui_midi_key_range(zynthian_gui_base):
 			midi_note += 1
 
 			if self.black_keys_pattern[i % 7]:
-				if self.note_low>midi_note or self.note_high<midi_note:
+				if self.note_low > midi_note or self.note_high < midi_note:
 					bgcolor = "#707070"
 				else:
 					bgcolor = "#000000"
@@ -199,41 +198,42 @@ class zynthian_gui_midi_key_range(zynthian_gui_base):
 	@staticmethod
 	def get_midi_note_name(num):
 		note_names = ("C","C#","D","D#","E","F","F#","G","G#","A","A#","B")
-		scale = int(num/12)-2
-		num = int(num%12)
-		return "{}{}".format(note_names[num],scale)
+		scale = int(num / 12) - 2
+		num = int(num % 12)
+		return "{}{}".format(note_names[num], scale)
 
 
 	def plot_text(self):
-		fs = int(1.7*zynthian_gui_config.font_size)
+		fs = int(1.7 * zynthian_gui_config.font_size)
 
 		self.nlow_text=self.note_info_canvas.create_text(
-			int(zynthian_gui_config.ctrl_width/2),
-			int((self.note_info_canvas_height-fs)/1.5),
-			width=5*fs,
+			int(zynthian_gui_config.ctrl_width / 2),
+			int((self.note_info_canvas_height-fs) / 1.5),
+			width=5 * fs,
 			justify=tkinter.CENTER,
 			fill=zynthian_gui_config.color_ctrl_tx,
-			font=(zynthian_gui_config.font_family,fs),
+			font=(zynthian_gui_config.font_family, fs),
 			text=self.get_midi_note_name(self.note_low))
 
 		self.nhigh_text=self.note_info_canvas.create_text(
-			self.piano_canvas_width-int(zynthian_gui_config.ctrl_width/2),
-			int((self.note_info_canvas_height-fs)/1.5),
-			width=5*fs,
+			self.piano_canvas_width - int(zynthian_gui_config.ctrl_width / 2),
+			int((self.note_info_canvas_height-fs) / 1.5),
+			width=5 * fs,
 			justify=tkinter.CENTER,
 			fill=zynthian_gui_config.color_ctrl_tx,
-			font=(zynthian_gui_config.font_family,fs),
+			font=(zynthian_gui_config.font_family, fs),
 			text=self.get_midi_note_name(self.note_high))
 
 
 		self.learn_text=self.note_info_canvas.create_text(
 			zynthian_gui_config.display_width  / 2,
 			int((self.note_info_canvas_height-fs) / 1.5),
-			width=5*fs,
+			width=5 * fs,
 			justify=tkinter.CENTER,
 			fill=zynthian_gui_config.color_ml,
 			font=(zynthian_gui_config.font_family, int(fs * 0.7)),
-			text="learning...")
+			text="learning...",
+			state=tkinter.HIDDEN)
 
 
 	def update_text(self):
@@ -244,8 +244,8 @@ class zynthian_gui_midi_key_range(zynthian_gui_base):
 	def set_zctrls(self):
 		if self.shown:
 			if not self.halftone_zgui_ctrl:
-				self.halftone_zctrl=zynthian_controller(self, 'semitone transpose', 'semitone transpose', { 'value_min':-12, 'value_max':12 })
-				self.halftone_zgui_ctrl=zynthian_gui_controller(self.zctrl_pos[0], self.main_frame, self.halftone_zctrl, False)
+				self.halftone_zctrl = zynthian_controller(self, 'semitone transpose', 'semitone transpose', { 'value_min':-12, 'value_max':12 })
+				self.halftone_zgui_ctrl = zynthian_gui_controller(self.zctrl_pos[0], self.main_frame, self.halftone_zctrl, False)
 			self.halftone_zgui_ctrl.setup_zynpot()
 			self.halftone_zgui_ctrl.erase_midi_bind()
 			self.halftone_zctrl.set_value(self.halftone_trans)
@@ -290,37 +290,38 @@ class zynthian_gui_midi_key_range(zynthian_gui_base):
 		super().show()
 		self.zyngui.screens["control"].unlock_controllers()
 		self.set_zctrls()
-		lib_zyncore.set_midi_learning_mode(self.learn_mode)
-
+		self.update_piano()
+		
 
 	def hide(self):
 		super().hide()
-		lib_zyncore.set_midi_learning_mode(0)
+		self.end_midi_learn()
 
 
 	def zynpot_cb(self, i, dval):
-		if i == 0:
+		if i == zynthian_gui_config.ENC_LAYER:
 			self.halftone_zgui_ctrl.zynpot_cb(dval)
-		elif i ==1:
+		elif i == zynthian_gui_config.ENC_SNAPSHOT:
 			self.octave_zgui_ctrl.zynpot_cb(dval)
-		elif i ==2:
+		elif i == zynthian_gui_config.ENC_BACK:
 			self.nlow_zgui_ctrl.zynpot_cb(dval)
-		elif i ==3:
+		elif i == zynthian_gui_config.ENC_SELECT:
 			self.nhigh_zgui_ctrl.zynpot_cb(dval)
 		else:
 			return False
 		return True
 
 
-	def toggle_midi_learn(self):
-		if self.learn_mode:
-			self.learn_mode = False
-			#lib_zyncore.set_midi_learning_mode(0)
-			self.note_info_canvas.itemconfig(self.learn_text, state=tkinter.HIDDEN)
-		else:
-			self.learn_mode = True
-			#lib_zyncore.set_midi_learning_mode(1)
-			self.note_info_canvas.itemconfig(self.learn_text, state=tkinter.NORMAL)
+	def start_midi_learn(self):
+		self.learn_mode = 1
+		self.note_info_canvas.itemconfig(self.learn_text, state=tkinter.NORMAL)
+		lib_zyncore.set_midi_learning_mode(True)
+
+
+	def end_midi_learn(self):
+		self.learn_mode = 0
+		self.note_info_canvas.itemconfig(self.learn_text, state=tkinter.HIDDEN)
+		lib_zyncore.set_midi_learning_mode(False)
 
 
 	def send_controller_value(self, zctrl):
@@ -359,20 +360,24 @@ class zynthian_gui_midi_key_range(zynthian_gui_base):
 
 
 	def learn_note_range(self, num):
-		if not self.learn_mode:
-			return
-		if self.learn_toggle == 0 or num <= self.note_low:
+		if self.learn_mode == 1:
 			self.nlow_zctrl.set_value(num)
 			if self.note_low > self.note_high:
 				self.nhigh_zctrl.set_value(127)
-			self.learn_toggle = 1
-		else:
+			self.learn_mode = 2
+		elif self.learn_mode == 2:
 			self.nhigh_zctrl.set_value(num)
-			self.learn_toggle = 0
+			self.end_midi_learn()
 
 
 	def switch_select(self, t='S'):
 		self.zyngui.close_screen()
+
+
+	def switch(self, switch, type):
+		if switch == zynthian_gui_config.ENC_BACK and self.learn_mode:
+			self.end_midi_learn()
+			return True
 
 
 	def set_select_path(self):

--- a/zyngui/zynthian_gui_midi_key_range.py
+++ b/zyngui/zynthian_gui_midi_key_range.py
@@ -391,11 +391,13 @@ class zynthian_gui_midi_key_range(zynthian_gui_base):
 		if switch == zynthian_gui_config.ENC_BACK and self.learn_mode:
 			self.end_midi_learn()
 			return True
-		elif switch == zynthian_gui_config.ENC_SNAPSHOT and type == "S":
+		elif switch == zynthian_gui_config.ENC_SNAPSHOT:
 			if self.learn_mode:
 				self.end_midi_learn()
 			else:
 				self.start_midi_learn()
+			return True
+		elif switch == zynthian_gui_config.ENC_LAYER:
 			return True
 
 

--- a/zyngui/zynthian_gui_midi_recorder.py
+++ b/zyngui/zynthian_gui_midi_recorder.py
@@ -5,7 +5,7 @@
 # 
 # Zynthian GUI MIDI Recorder Class
 # 
-# Copyright (C) 2015-2018 Fernando Moyano <jofemodo@zynthian.org>
+# Copyright (C) 2015-2022 Fernando Moyano <jofemodo@zynthian.org>
 #
 #******************************************************************************
 # 
@@ -237,7 +237,6 @@ class zynthian_gui_midi_recorder(zynthian_gui_selector):
 	def switch(self, swi, t='S'):
 		if swi == 0:
 			if t == 'S':
-				self.zyngui.replace_screen('audio_recorder')
 				return True
 
 

--- a/zyngui/zynthian_gui_mixer.py
+++ b/zyngui/zynthian_gui_mixer.py
@@ -146,7 +146,7 @@ class zynthian_gui_mixer_strip():
 		font_fader = (zynthian_gui_config.font_family, int(0.9 * font_size))
 		font_icons = ("forkawesome", int(0.3 * self.width))
 
-		self.fader_text_len = int(1.1 * self.fader_height / font_size)
+		self.fader_text_limit = self.fader_top + int(0.1 * self.fader_height)
 
 		'''
 		Create GUI elements
@@ -245,9 +245,6 @@ class zynthian_gui_mixer_strip():
 			# Rest of chains
 			elif self.layer.preset_name:
 				res2 = self.layer.preset_name
-			# Limit text len
-			if len(res2)>self.fader_text_len:
-				res2 = res2[0:self.fader_text_len]
 			return res1+res2
 		return default_text
 
@@ -268,7 +265,16 @@ class zynthian_gui_mixer_strip():
 			else:
 				strip_txt = "X"
 			self.parent.main_canvas.itemconfig(self.legend_strip_txt, text=strip_txt)
-			self.parent.main_canvas.itemconfig(self.legend, text=self.get_legend_text("None"), state=tkinter.NORMAL)
+			label = self.get_legend_text("None")
+			self.parent.main_canvas.itemconfig(self.legend, text=label, state=tkinter.NORMAL)
+			bounds = self.parent.main_canvas.bbox(self.legend)
+			if bounds[1] < self.fader_text_limit:
+				while bounds and bounds[1] < self.fader_text_limit:
+					label = label[:-1]
+					self.parent.main_canvas.itemconfig(self.legend, text=label)
+					bounds = self.parent.main_canvas.bbox(self.legend)
+				label += "..."
+				self.parent.main_canvas.itemconfig(self.legend, text=label)
 
 		try:
 			if self.layer.engine and self.layer.engine.type == "MIDI Tool" or self.layer.midi_chan is None:

--- a/zyngui/zynthian_gui_mixer.py
+++ b/zyngui/zynthian_gui_mixer.py
@@ -750,7 +750,10 @@ class zynthian_gui_mixer(zynthian_gui_base.zynthian_gui_base):
 			self.main_canvas.tag_bind(self.horiz_scroll_bg, "<Button-4>", self.on_fader_wheel_up)
 			self.main_canvas.tag_bind(self.horiz_scroll_bg, "<Button-5>", self.on_fader_wheel_down)
 
-		self.zynmixer.enable_dpm(False) # Disable DPM by default - they get enabled when mixer is shown
+		# Disable channel DPM by default - they get enabled when mixer is shown
+		for chan in range(self.zyngui.zynmixer.get_max_channels()):
+			self.zyngui.zynmixer.enable_dpm(chan, False)
+
 		if zynthian_gui_config.show_cpu_status:
 			self.meter_mode = self.METER_CPU
 		else:
@@ -764,13 +767,18 @@ class zynthian_gui_mixer(zynthian_gui_base.zynthian_gui_base):
 
 	# Function to handle hiding display
 	def hide(self):
-		self.zynmixer.enable_dpm(False)
+		# Disable channel DPM when mixer not shown
+		for chan in range(self.zyngui.zynmixer.get_max_channels()):
+			self.zyngui.zynmixer.enable_dpm(chan, False)
 		self.end_midi_learn()
 		super().hide()
 
 
 	# Function to handle showing display
 	def show(self):
+		# Only enable channel DPM when mixer shown
+		for chan in range(self.zyngui.zynmixer.get_max_channels()):
+			self.zyngui.zynmixer.enable_dpm(chan, zynthian_gui_config.enable_dpm)
 		self.zyngui.screens["control"].unlock_controllers()
 		self.refresh_visible_strips()
 		if self.selected_chain_index == None:
@@ -778,7 +786,6 @@ class zynthian_gui_mixer(zynthian_gui_base.zynthian_gui_base):
 		else:
 			self.select_chain_by_index(self.selected_chain_index)
 		self.setup_zynpots()
-		self.zynmixer.enable_dpm(True)
 		super().show()
 
 
@@ -794,7 +801,8 @@ class zynthian_gui_mixer(zynthian_gui_base.zynthian_gui_base):
 			self.main_mixbus_strip.draw_dpm()
 			for strip in self.visible_mixer_strips:
 				if not strip.hidden:
-					strip.draw_dpm()
+					if zynthian_gui_config.enable_dpm:
+						strip.draw_dpm()
 					strip.refresh_status()
 				# Redraw changed strips
 				'''

--- a/zyngui/zynthian_gui_mixer.py
+++ b/zyngui/zynthian_gui_mixer.py
@@ -171,8 +171,8 @@ class zynthian_gui_mixer_strip():
 		self.dpm_m_b = self.parent.main_canvas.create_rectangle(self.dpm_b_x, self.dpm_b_y - self.dpm_scale_lh, self.dpm_b_x + self.dpm_width, self.dpm_b_y - self.dpm_scale_lm, width=0, fill=self.medium_color, tags=("fader:%s"%(self.fader_bg), "strip:%s"%(self.fader_bg), "audio_strip:%s"%(self.fader_bg), "dpm"))
 		self.dpm_l_b = self.parent.main_canvas.create_rectangle(self.dpm_b_x, self.dpm_b_y - self.dpm_scale_lm, self.dpm_b_x + self.dpm_width,  self.fader_bottom, width=0, fill=self.low_color, tags=("fader:%s"%(self.fader_bg), "strip:%s"%(self.fader_bg), "audio_strip:%s"%(self.fader_bg), "dpm"))
 		self.dpm_b_b = self.parent.main_canvas.create_rectangle(self.dpm_b_x, self.fader_bottom, self.dpm_b_x + self.dpm_width, self.fader_top, width=0, fill=self.fader_bg_color, tags=("fader:%s"%(self.fader_bg), "strip:%s"%(self.fader_bg), "audio_strip:%s"%(self.fader_bg), "dpm"))
-		self.dpm_hold_a = self.parent.main_canvas.create_rectangle(self.dpm_a_x, self.fader_bottom, self.dpm_a_x + self.dpm_width, self.fader_bottom, width=0, fill=self.low_color, tags=("fader:%s"%(self.fader_bg), "strip:%s"%(self.fader_bg), "audio_strip:%s"%(self.fader_bg)), state="hidden")
-		self.dpm_hold_b = self.parent.main_canvas.create_rectangle(self.dpm_b_x, self.fader_bottom, self.dpm_b_x + self.dpm_width, self.fader_bottom, width=0, fill=self.low_color, tags=("fader:%s"%(self.fader_bg), "strip:%s"%(self.fader_bg), "audio_strip:%s"%(self.fader_bg)), state="hidden")
+		self.dpm_hold_a = self.parent.main_canvas.create_rectangle(self.dpm_a_x, self.fader_bottom, self.dpm_a_x + self.dpm_width, self.fader_bottom, width=0, fill=self.low_color, tags=("fader:%s"%(self.fader_bg), "strip:%s"%(self.fader_bg), "audio_strip:%s"%(self.fader_bg)), state=tkinter.HIDDEN)
+		self.dpm_hold_b = self.parent.main_canvas.create_rectangle(self.dpm_b_x, self.fader_bottom, self.dpm_b_x + self.dpm_width, self.fader_bottom, width=0, fill=self.low_color, tags=("fader:%s"%(self.fader_bg), "strip:%s"%(self.fader_bg), "audio_strip:%s"%(self.fader_bg)), state=tkinter.HIDDEN)
 		self.mono_text = self.parent.main_canvas.create_text(int(self.dpm_b_x + self.dpm_width / 2), int(self.fader_top + self.fader_height / 2), text="?", state=tkinter.HIDDEN)
 
 		# 0dB line
@@ -193,7 +193,7 @@ class zynthian_gui_mixer_strip():
 		# Balance indicator
 		self.balance_left = self.parent.main_canvas.create_rectangle(x, self.balance_top, int(fader_centre - 0.5), self.balance_top + self.balance_height, fill=self.left_color, width=0, tags=("strip:%s"%(self.fader_bg), "balance:%s"%(self.fader_bg), "audio_strip:%s"%(self.fader_bg)))
 		self.balance_right = self.parent.main_canvas.create_rectangle(int(fader_centre + 0.5), self.balance_top, self.width, self.balance_top + self.balance_height , fill=self.right_color, width=0, tags=("strip:%s"%(self.fader_bg), "balance:%s"%(self.fader_bg), "audio_strip:%s"%(self.fader_bg)))
-		self.balance_text = self.parent.main_canvas.create_text(int(fader_centre), int(self.balance_top + self.balance_height / 2), text="?", state=tkinter.HIDDEN, tags=("strip:%s"%(self.fader_bg)))
+		self.balance_text = self.parent.main_canvas.create_text(int(fader_centre), int(self.balance_top + self.balance_height / 2), text="?", state=tkinter.HIDDEN)
 
 		# Fader indicators
 		self.status_indicator = self.parent.main_canvas.create_text(x + 2, self.fader_top + 2, fill="#009000", anchor="nw", tags=("strip:%s"%(self.fader_bg)))
@@ -218,16 +218,16 @@ class zynthian_gui_mixer_strip():
 
 	# Function to hide mixer strip
 	def hide(self):
-		self.parent.main_canvas.itemconfig("strip:%s"%(self.fader_bg), state="hidden")
+		self.parent.main_canvas.itemconfig("strip:%s"%(self.fader_bg), state=tkinter.HIDDEN)
 		self.hidden = True
 
 
 	# Function to show mixer strip
 	def show(self):
-		self.parent.main_canvas.itemconfig("strip:%s"%(self.fader_bg), state="normal")
+		self.parent.main_canvas.itemconfig("strip:%s"%(self.fader_bg), state=tkinter.NORMAL)
 		try:
 			if self.layer.engine.type == "MIDI Tool":
-				self.parent.main_canvas.itemconfig("audio_strip:%s"%(self.fader_bg), state="hidden")
+				self.parent.main_canvas.itemconfig("audio_strip:%s"%(self.fader_bg), state=tkinter.HIDDEN)
 		except:
 			pass
 		self.hidden = False
@@ -261,14 +261,14 @@ class zynthian_gui_mixer_strip():
 		self.parent.main_canvas.coords(self.fader_bg_color, self.x, self.fader_top, self.x + self.width, self.fader_bottom)
 		if self.layer.midi_chan==self.MAIN_CHANNEL_INDEX:
 			self.parent.main_canvas.itemconfig(self.legend_strip_txt, text="Main")
-			self.parent.main_canvas.itemconfig(self.legend, text=self.get_legend_text("NoFX"), state="normal")
+			self.parent.main_canvas.itemconfig(self.legend, text=self.get_legend_text("NoFX"), state=tkinter.NORMAL)
 		else:
 			if isinstance(self.layer.midi_chan, int):
 				strip_txt = str(self.layer.midi_chan + 1)
 			else:
 				strip_txt = "X"
 			self.parent.main_canvas.itemconfig(self.legend_strip_txt, text=strip_txt)
-			self.parent.main_canvas.itemconfig(self.legend, text=self.get_legend_text("None"), state="normal")
+			self.parent.main_canvas.itemconfig(self.legend, text=self.get_legend_text("None"), state=tkinter.NORMAL)
 
 		try:
 			if self.layer.engine and self.layer.engine.type == "MIDI Tool" or self.layer.midi_chan is None:
@@ -307,25 +307,25 @@ class zynthian_gui_mixer_strip():
 		self.parent.main_canvas.coords(self.dpm_b_a, (self.dpm_a_x, self.fader_top, self.dpm_a_x + self.dpm_width, self.fader_top + level_a))
 		self.parent.main_canvas.coords(self.dpm_hold_a, (self.dpm_a_x, self.dpm_a_y - hold_a, self.dpm_a_x + self.dpm_width, self.dpm_a_y - hold_a - 1))
 		if hold_a >= self.dpm_scale_lh:
-			self.parent.main_canvas.itemconfig(self.dpm_hold_a, state="normal", fill="#FF0000")
+			self.parent.main_canvas.itemconfig(self.dpm_hold_a, state=tkinter.NORMAL, fill="#FF0000")
 		elif hold_a >= self.dpm_scale_lm:
-			self.parent.main_canvas.itemconfig(self.dpm_hold_a, state="normal", fill="#FFFF00")
+			self.parent.main_canvas.itemconfig(self.dpm_hold_a, state=tkinter.NORMAL, fill="#FFFF00")
 		elif hold_a > 0:
-			self.parent.main_canvas.itemconfig(self.dpm_hold_a, state="normal", fill=self.dpm_hold_color)
+			self.parent.main_canvas.itemconfig(self.dpm_hold_a, state=tkinter.NORMAL, fill=self.dpm_hold_color)
 		else:
-			self.parent.main_canvas.itemconfig(self.dpm_hold_a, state="hidden")
+			self.parent.main_canvas.itemconfig(self.dpm_hold_a, state=tkinter.HIDDEN)
 
 		# Draw right meter
 		self.parent.main_canvas.coords(self.dpm_b_b, (self.dpm_b_x, self.fader_top, self.dpm_b_x + self.dpm_width, self.fader_top + level_b))
 		self.parent.main_canvas.coords(self.dpm_hold_b, (self.dpm_b_x, self.dpm_b_y - hold_b, self.dpm_b_x + self.dpm_width, self.dpm_b_y - hold_b - 1))
 		if hold_b >= self.dpm_scale_lh:
-			self.parent.main_canvas.itemconfig(self.dpm_hold_b, state="normal", fill="#FF0000")
+			self.parent.main_canvas.itemconfig(self.dpm_hold_b, state=tkinter.NORMAL, fill="#FF0000")
 		elif hold_b >= self.dpm_scale_lm:
-			self.parent.main_canvas.itemconfig(self.dpm_hold_b, state="normal", fill="#FFFF00")
+			self.parent.main_canvas.itemconfig(self.dpm_hold_b, state=tkinter.NORMAL, fill="#FFFF00")
 		elif hold_b > 0:
-			self.parent.main_canvas.itemconfig(self.dpm_hold_b, state="normal", fill=self.dpm_hold_color)
+			self.parent.main_canvas.itemconfig(self.dpm_hold_b, state=tkinter.NORMAL, fill=self.dpm_hold_color)
 		else:
-			self.parent.main_canvas.itemconfig(self.dpm_hold_b, state="hidden")
+			self.parent.main_canvas.itemconfig(self.dpm_hold_b, state=tkinter.HIDDEN)
 
 
 	def flag_redraw(self, all=False):
@@ -433,7 +433,7 @@ class zynthian_gui_mixer_strip():
 		elif self.midi_learning == False:
 			if self.zctrls:
 				self.zctrls['level'].set_value(value)
-		self.redraw_controls() #TODO: Set flag for next refresh
+		self.flag_redraw()
 
 
 	# Function to get volume value
@@ -449,7 +449,7 @@ class zynthian_gui_mixer_strip():
 		elif self.midi_learning == False:
 			if self.zctrls:
 				self.zctrls['level'].nudge(dval)
-		self.redraw_controls() #TODO: Set flag for next refresh
+		self.flag_redraw()
 
 
 	# Function to set balance value
@@ -460,7 +460,7 @@ class zynthian_gui_mixer_strip():
 		elif self.midi_learning == False:
 			if self.zctrls:
 				self.zctrls['balance'].set_value(value)
-		self.redraw_controls()
+		self.flag_redraw()
 
 
 	# Function to get balance value
@@ -476,7 +476,7 @@ class zynthian_gui_mixer_strip():
 		elif self.midi_learning == False:
 			if self.zctrls:
 				self.zctrls['balance'].nudge(dval)
-		self.flag_redraw() #TODO: Set flag for next refresh
+		self.flag_redraw()
 
 
 	# Function to reset volume
@@ -649,14 +649,22 @@ class zynthian_gui_mixer_strip():
 		if self.midi_learning == True:
 			self.parent.main_canvas.itemconfig(self.balance_text, state=tkinter.NORMAL)
 			self.parent.main_canvas.itemconfig(self.mono_text, state=tkinter.NORMAL)
-		else:
+		elif self.midi_learning == False:
 			self.parent.main_canvas.itemconfig(self.balance_text, state=tkinter.HIDDEN)
 			self.parent.main_canvas.itemconfig(self.mono_text, state=tkinter.HIDDEN)
-		if self.midi_learning != True and self.midi_learning != False:
-			self.parent.main_canvas.itemconfig(mode, state=tkinter.NORMAL)
-		if mode == self.legend:
+		elif mode == self.legend:
 			self.zctrls['level'].init_midi_learn()
-		
+		elif mode == self.balance_text:
+			self.zctrls['balance'].init_midi_learn()
+			self.parent.main_canvas.itemconfig(mode, state=tkinter.NORMAL)
+		elif mode == self.mute_text:
+			self.zctrls['mute'].init_midi_learn()
+		elif mode == solo_text:
+			self.zctrls['solo'].init_midi_learn()
+		elif mode == self.mono_text:
+			self.zctrls['mono'].init_midi_learn()
+			self.parent.main_canvas.itemconfig(mode, state=tkinter.NORMAL)
+
 		self.flag_redraw()
 
 
@@ -671,7 +679,7 @@ class zynthian_gui_mixer(zynthian_gui_base.zynthian_gui_base):
 		self.zynmixer = self.zyngui.zynmixer
 		self.zynmixer.set_ctrl_update_cb(self.cb_ctrl_change)
 		self.MAIN_CHANNEL_INDEX = zynthian_gui_config.zyngui.zynmixer.get_max_channels() 
-		self.chan2strip = [None] * self.MAIN_CHANNEL_INDEX
+		self.chan2strip = [None] * (self.MAIN_CHANNEL_INDEX + 1)
 
 		self.buttonbar_config = [
 			(0, 'MUTE\n[menu]'),
@@ -876,8 +884,8 @@ class zynthian_gui_mixer(zynthian_gui_base.zynthian_gui_base):
 
 	# Function refresh and populate visible mixer strips
 	def refresh_visible_strips(self):
-
-		self.chan2strip = [None] * self.MAIN_CHANNEL_INDEX
+		for index in range(len(self.chan2strip)):
+			self.chan2strip[index] = None
 		layers = copy.copy(self.zyngui.screens['layer'].get_root_layers())
 		main_fx_layer = self.zyngui.screens['layer'].get_main_fxchain_root_layer()
 
@@ -902,7 +910,7 @@ class zynthian_gui_mixer(zynthian_gui_base.zynthian_gui_base):
 				else:
 					self.visible_mixer_strips[offset].zctrls = None
 					
-
+		self.chan2strip[self.MAIN_CHANNEL_INDEX] = self.main_mixbus_strip
 		self.main_mixbus_strip.redraw_controls()
 		self.highlight_selected_chain()
 

--- a/zyngui/zynthian_gui_mixer.py
+++ b/zyngui/zynthian_gui_mixer.py
@@ -659,7 +659,7 @@ class zynthian_gui_mixer_strip():
 			self.parent.main_canvas.itemconfig(mode, state=tkinter.NORMAL)
 		elif mode == self.mute_text:
 			self.zctrls['mute'].init_midi_learn()
-		elif mode == solo_text:
+		elif mode == self.solo_text:
 			self.zctrls['solo'].init_midi_learn()
 		elif mode == self.mono_text:
 			self.zctrls['mono'].init_midi_learn()
@@ -943,6 +943,8 @@ class zynthian_gui_mixer(zynthian_gui_base.zynthian_gui_base):
 				options["[  ] Recording Primed"] = primed_option
 		options["> Audio Chain ---------------"] = None
 		options["Add Audio-FX"] = "Add"
+		options["Clean MIDI-Learn"] = "Clean"
+
 		self.zyngui.screens['option'].config("Main Chain Options", options, self.mainfx_options_cb)
 		self.zyngui.show_screen('option')
 
@@ -956,6 +958,12 @@ class zynthian_gui_mixer(zynthian_gui_base.zynthian_gui_base):
 		elif param == "Primed":
 			self.zyngui.audio_recorder.toggle_prime(self.MAIN_CHANNEL_INDEX)
 			self.show_mainfx_options()
+		elif param == "Clean":
+			self.zyngui.show_confirm("Do you really want to clean MIDI-learn for this chain?", self.midi_unlearn_confirmed)
+
+
+	def midi_unlearn_confirmed(self, param):
+		self.zynmixer.midi_unlearn_chan(self.MAIN_CHANNEL_INDEX)
 
 
 	#--------------------------------------------------------------------------
@@ -976,7 +984,7 @@ class zynthian_gui_mixer(zynthian_gui_base.zynthian_gui_base):
 		elif swi == zynthian_gui_config.ENC_BACK:
 			if t == "S":
 				if self.midi_learning:
-					self.end_midi_learn()
+					self.zyngui.exit_midi_learn_mode()
 					return False
 				return True
 			elif t == "B":
@@ -1105,13 +1113,13 @@ class zynthian_gui_mixer(zynthian_gui_base.zynthian_gui_base):
 				self.visible_mixer_strips[self.selected_chain_index].enable_midi_learn(True)
 			self.midi_learning = True
 
-
+    
 	def end_midi_learn(self):
 		for strip in self.visible_mixer_strips:
 			strip.enable_midi_learn(False)
 		self.main_mixbus_strip.enable_midi_learn(False)
 		self.midi_learning = False
-		
+
 
 	def cb_ctrl_change(self, chan, ctrl, value):
 		self.pending_refresh_queue.add(self.chan2strip[chan])

--- a/zyngui/zynthian_gui_mixer.py
+++ b/zyngui/zynthian_gui_mixer.py
@@ -1094,16 +1094,6 @@ class zynthian_gui_mixer(zynthian_gui_base.zynthian_gui_base):
 		self.refresh_visible_strips()
 
 
-	# Function to handle CUIA SELECT_UP command (reversed to drive down screen with DOWN action)
-	def select_up(self):
-		self.zynpot_cb(zynthian_gui_config.ENC_SELECT, 1)
-
-
-	# Function to handle CUIA SELECT_DOWN command
-	def select_down(self):
-		self.zynpot_cb(zynthian_gui_config.ENC_SELECT, -1)
-
-
 	# Pre-select all controls in a chain to allow selection of actual control to MIDI learn
 	def start_midi_learn(self):
 		if self.selected_layer and self.selected_layer.midi_chan is not None:

--- a/zyngui/zynthian_gui_mixer.py
+++ b/zyngui/zynthian_gui_mixer.py
@@ -193,10 +193,10 @@ class zynthian_gui_mixer_strip():
 		# Balance indicator
 		self.balance_left = self.parent.main_canvas.create_rectangle(x, self.balance_top, int(fader_centre - 0.5), self.balance_top + self.balance_height, fill=self.left_color, width=0, tags=("strip:%s"%(self.fader_bg), "balance:%s"%(self.fader_bg), "audio_strip:%s"%(self.fader_bg)))
 		self.balance_right = self.parent.main_canvas.create_rectangle(int(fader_centre + 0.5), self.balance_top, self.width, self.balance_top + self.balance_height , fill=self.right_color, width=0, tags=("strip:%s"%(self.fader_bg), "balance:%s"%(self.fader_bg), "audio_strip:%s"%(self.fader_bg)))
-		self.balance_text = self.parent.main_canvas.create_text(int(fader_centre), int(self.balance_top + self.balance_height / 2), text="?", state=tkinter.HIDDEN)
+		self.balance_text = self.parent.main_canvas.create_text(int(fader_centre), int(self.balance_top + self.balance_height / 2), text="?", state=tkinter.HIDDEN, tags=("strip:%s"%(self.fader_bg)))
 
 		# Fader indicators
-		self.indicator = self.parent.main_canvas.create_text(x + 2, self.fader_top + 2, fill="#009000", anchor="nw")
+		self.status_indicator = self.parent.main_canvas.create_text(x + 2, self.fader_top + 2, fill="#009000", anchor="nw", tags=("strip:%s"%(self.fader_bg)))
 
 		self.parent.main_canvas.tag_bind("fader:%s"%(self.fader_bg), "<ButtonPress-1>", self.on_fader_press)
 		self.parent.main_canvas.tag_bind("fader:%s"%(self.fader_bg), "<B1-Motion>", self.on_fader_motion)
@@ -278,11 +278,14 @@ class zynthian_gui_mixer_strip():
 
 		self.draw_dpm()
 		self.redraw_controls()
+		self.refresh_status()
 
+
+	def refresh_status(self):
 		if self.parent.zyngui.audio_recorder.is_primed(self.layer.midi_chan):
-			self.parent.main_canvas.itemconfig(self.indicator, text="{}\uf111".format(self.layer.status), fill=self.high_color)
+			self.parent.main_canvas.itemconfig(self.status_indicator, text="{}\uf111".format(self.layer.status), fill=self.high_color)
 		else:
-			self.parent.main_canvas.itemconfig(self.indicator, text=self.layer.status, fill="#009000")
+			self.parent.main_canvas.itemconfig(self.status_indicator, text=self.layer.status, fill="#009000")
 	
 
 	# Function to draw the DPM level meter for a mixer strip
@@ -784,6 +787,7 @@ class zynthian_gui_mixer(zynthian_gui_base.zynthian_gui_base):
 			for strip in self.visible_mixer_strips:
 				if not strip.hidden:
 					strip.draw_dpm()
+					strip.refresh_status()
 				# Redraw changed strips
 				'''
 				for strip in self.visible_mixer_strips:

--- a/zyngui/zynthian_gui_patterneditor.py
+++ b/zyngui/zynthian_gui_patterneditor.py
@@ -6,7 +6,7 @@
 # Zynthian GUI Step-Sequencer Class
 #
 # Copyright (C) 2015-2022 Fernando Moyano <jofemodo@zynthian.org>
-# Copyright (C) 2015-2022 Brian Walton <brian@riban.co.uk>
+#                         Brian Walton <brian@riban.co.uk>
 #
 #******************************************************************************
 #
@@ -198,6 +198,8 @@ class zynthian_gui_patterneditor():
 	# Function to show GUI
 	#   params: Pattern parameters to edit {'pattern':x, 'channel':x, 'pad':x (optional)}
 	def show(self, params=None):
+		if self.zyngui.test_mode:
+			logging.warning("TEST_MODE: {}".format(self.__class__.__module__))
 		try:
 			self.channel = params['channel']
 			self.load_pattern(params['pattern'])

--- a/zyngui/zynthian_gui_stepsequencer.py
+++ b/zyngui/zynthian_gui_stepsequencer.py
@@ -901,22 +901,6 @@ class zynthian_gui_stepsequencer(zynthian_gui_base.zynthian_gui_base):
 			return True
 
 
-	# Function to handle CUIA SELECT_UP command (reversed to drive down screen with DOWN action)
-	def select_up(self):
-		if self.lst_menu.winfo_viewable():
-			self.zynpot_cb(zynthian_gui_config.ENC_SELECT, -1)
-		else:
-			self.zynpot_cb(zynthian_gui_config.ENC_SELECT, 1)
-
-
-	# Function to handle CUIA SELECT_DOWN command
-	def select_down(self):
-		if self.lst_menu.winfo_viewable():
-			self.zynpot_cb(zynthian_gui_config.ENC_SELECT, 1)
-		else:
-			self.zynpot_cb(zynthian_gui_config.ENC_SELECT, -1)
-
-
 	# Function to handle CUIA ARROW_UP
 	def arrow_up(self):
 		if self.lst_menu.winfo_viewable():

--- a/zyngui/zynthian_gui_stepsequencer.py
+++ b/zyngui/zynthian_gui_stepsequencer.py
@@ -6,7 +6,7 @@
 # Zynthian GUI Step-Sequencer Class
 #
 # Copyright (C) 2015-2022 Fernando Moyano <jofemodo@zynthian.org>
-# Copyright (C) 2015-2022 Brian Walton <brian@riban.co.uk>
+#                         Brian Walton <brian@riban.co.uk>
 #
 #******************************************************************************
 #
@@ -548,6 +548,8 @@ class zynthian_gui_stepsequencer(zynthian_gui_base.zynthian_gui_base):
 	# Function to show GUI
 	def show(self):
 		if not self.shown:
+			if self.zyngui.test_mode:
+				logging.warning("TEST_MODE: {}".format(self.__class__.__module__))
 			self.main_frame.grid_propagate(False)
 			self.main_frame.grid(column=0, row=0)
 			self.zyngui.screens["control"].unlock_controllers()

--- a/zyngui/zynthian_gui_touchscreen_calibration.py
+++ b/zyngui/zynthian_gui_touchscreen_calibration.py
@@ -5,7 +5,7 @@
 # 
 # Zynthian GUI Touchscreen Calibration Class
 # 
-# Copyright (C) 2020 Brian Walton <brian@riban.co.uk>
+# Copyright (C) 2022 Brian Walton <brian@riban.co.uk>
 #
 #******************************************************************************
 # 
@@ -397,6 +397,8 @@ class zynthian_gui_touchscreen_calibration:
 	# 	Show display
 	def show(self):
 		if not self.shown:
+			if self.zyngui.test_mode:
+				logging.warning("TEST_MODE: {}".format(self.__class__.__module__))
 			self.shown=True
 			self.device_name = None
 			self.ctm = [1,0,0,0,1,0,0,0,1]

--- a/zyngui/zynthian_gui_zynpad.py
+++ b/zyngui/zynthian_gui_zynpad.py
@@ -6,7 +6,7 @@
 # Zynthian GUI Step-Sequencer Class
 #
 # Copyright (C) 2015-2022 Fernando Moyano <jofemodo@zynthian.org>
-# Copyright (C) 2015-2022 Brian Walton <brian@riban.co.uk>
+#                         Brian Walton <brian@riban.co.uk>
 #
 #******************************************************************************
 #
@@ -107,6 +107,8 @@ class zynthian_gui_zynpad():
 	# Function to show GUI
 	#   params: Misc parameters
 	def show(self, params):
+		if self.zyngui.test_mode:
+			logging.warning("TEST_MODE: {}".format(self.__class__.__module__))
 		libseq.updateSequenceInfo()
 		self.main_frame.tkraise()
 		self.setup_encoders()

--- a/zynlibs/zynaudioplayer/player.c
+++ b/zynlibs/zynaudioplayer/player.c
@@ -1192,7 +1192,7 @@ int is_debug() {
 unsigned int get_player_count() {
     int count = 0;
     for(int i = 0; i < MAX_PLAYERS; ++i)
-        if(g_players)
+        if(g_players[i])
             ++count;
     return count;
 }

--- a/zynlibs/zynaudioplayer/player.c
+++ b/zynlibs/zynaudioplayer/player.c
@@ -357,16 +357,13 @@ void* file_thread_fn(void * param) {
         srcData.data_in = pBufferIn;
         srcData.data_out = pBufferOut;
         pPlayer->src_ratio = (float)g_samplerate / pPlayer->sf_info.samplerate;
-        if (pPlayer->src_ratio == 0)
+        if(pPlayer->src_ratio == 0)
             pPlayer->src_ratio = 1;
         srcData.src_ratio = pPlayer->src_ratio;
         pPlayer->pitch_shift = 1.0;
         pPlayer->pitch_bend = 0x2000;
         srcData.output_frames = pPlayer->buffer_size / pPlayer->sf_info.channels;
-        if(pPlayer->sf_info.samplerate)
-            pPlayer->frames = pPlayer->sf_info.frames * pPlayer->src_ratio; //!@todo Is this calc required?
-        else
-            pPlayer->frames = pPlayer->sf_info.frames;
+        pPlayer->frames = pPlayer->sf_info.frames * pPlayer->src_ratio;
         pPlayer->loop_end_src = pPlayer->loop_end * pPlayer->src_ratio;
         pPlayer->loop_start_src = pPlayer->loop_start * pPlayer->src_ratio;
         int nError;
@@ -616,8 +613,8 @@ void set_position(int player_handle, float time) {
         if(frames < pPlayer->loop_start_src)
             frames = pPlayer->loop_start_src;
     } else {
-        if(frames >= pPlayer->frames / pPlayer->src_ratio)
-            frames = pPlayer->frames / pPlayer->src_ratio - 1;
+        if(frames >= pPlayer->frames)
+            frames = pPlayer->frames - 1;
     }
     pPlayer->play_pos_frames = frames;
     pPlayer->file_read_status = SEEKING;
@@ -841,7 +838,7 @@ int on_jack_process(jack_nframes_t nFrames, void * arg) {
                 pPlayer->file_read_status = LOOPING;
             }
         } else {
-            if(pPlayer->play_pos_frames >= pPlayer->frames * pPlayer->src_ratio || eof) {
+            if(pPlayer->play_pos_frames >= pPlayer->frames || eof) {
                 // Reached end of file
                 pPlayer->play_pos_frames = 0;
                 pPlayer->play_state = STOPPING;

--- a/zynlibs/zynaudioplayer/zynaudioplayer.py
+++ b/zynlibs/zynaudioplayer/zynaudioplayer.py
@@ -42,7 +42,7 @@ from os.path import dirname, realpath
 
 
 class zynaudioplayer():
-
+    
 	#	Initiate library
 	def __init__(self):
 		try:

--- a/zynlibs/zynaudioplayer/zynaudioplayer.py
+++ b/zynlibs/zynaudioplayer/zynaudioplayer.py
@@ -47,6 +47,7 @@ class zynaudioplayer():
 	def __init__(self):
 		try:
 			self.handle = None
+			# Load or increment ref to lib
 			self.libaudioplayer = ctypes.cdll.LoadLibrary(dirname(realpath(__file__))+"/build/libzynaudioplayer.so")
 			handle = self.libaudioplayer.init()
 			if handle == -1:
@@ -74,21 +75,12 @@ class zynaudioplayer():
 
 
 	#	Destoy instance of shared library
-	def destroy(self):
+	def __del__(self):
+		self.set_control_cb(None)
 		if self.libaudioplayer:
 			self.libaudioplayer.end()
+			# Decrement ref to lib - when all ref removed shared lib will be unloaded
 			dlclose(self.libaudioplayer._handle)
-		self.libaudioplayer = None
-
-
-	#	Remove player from library
-	def remove_player(self):
-		if self.handle is None:
-			return
-		self.set_control_cb(None)
-		self.libaudioplayer.remove_player(self.handle)
-		self.libaudioplayer = None
-		self.handle = None
 		
 
 	#	Get jack client name

--- a/zynlibs/zynaudioplayer/zynaudioplayer.py
+++ b/zynlibs/zynaudioplayer/zynaudioplayer.py
@@ -41,7 +41,6 @@ from os.path import dirname, realpath
 #-------------------------------------------------------------------------------
 
 
-
 class zynaudioplayer():
 
 	#	Initiate library

--- a/zynlibs/zynmixer/__init__.py
+++ b/zynlibs/zynmixer/__init__.py
@@ -1,3 +1,1 @@
-from . import zynmixer
-
-zynmixer.init()
+#from . import zynmixer

--- a/zynlibs/zynmixer/mixer.c
+++ b/zynlibs/zynmixer/mixer.c
@@ -790,3 +790,7 @@ void removeOscClient(const char* client)
     }
 }
 
+size_t getMaxChannels()
+{
+    return MAX_CHANNELS;
+}

--- a/zynlibs/zynmixer/mixer.h
+++ b/zynlibs/zynmixer/mixer.h
@@ -145,10 +145,11 @@ float getDpm(int channel, int leg);
 float getDpmHold(int channel, int leg);
 
 /** @brief  Enable / disable peak programme metering
+*   @param  channel Index of channel
 *   @param  enable 1 to enable, 0 to disable
 *   @note   DPM increase CPU processing so may be disabled if this causes issues (like xruns)
 */
-void enableDpm(int enable);
+void enableDpm(int channel, int enable);
 
 /** @brief  Adds client to list of registered OSC clients
 *   @param  client IP address of client

--- a/zynlibs/zynmixer/mixer.h
+++ b/zynlibs/zynmixer/mixer.h
@@ -161,3 +161,9 @@ int addOscClient(const char* client);
 *   @param  client IP address of client
 */
 void removeOscClient(const char* client);
+
+
+/** @brief Get maximum quantity of channels
+*   @retval size_t Maximum quantity of channels
+*/
+size_t getMaxChannels();

--- a/zynlibs/zynmixer/zynmixer.py
+++ b/zynlibs/zynmixer/zynmixer.py
@@ -313,14 +313,12 @@ class zynmixer(zynthian_engine):
 
 
 	#	Function to enable or disable digital peak meters
+	#	chan: Mixer channel (256 for main mix bus)
 	#	enable: True to enable
-	def enable_dpm(self, enable):
+	def enable_dpm(self, chan, enable):
 		if self.lib_zynmixer is None:
 			return
-		if enable:
-			self.lib_zynmixer.enableDpm(1)
-		else:
-			self.lib_zynmixer.enableDpm(0)
+		self.lib_zynmixer.enableDpm(chan, int(enable))
 
 
 	#	Function to add OSC client registration

--- a/zynlibs/zynmixer/zynmixer.py
+++ b/zynlibs/zynmixer/zynmixer.py
@@ -405,8 +405,13 @@ class zynmixer(zynthian_engine):
 	# MIDI Learn
 	#--------------------------------------------------------------------------
 
-
 	def end_midi_learn(self, zctl):
 		logging.warning("Not implemented")
 		#TODO: Implement end_midi_learn
+
+
+	def midi_unlearn_chan(self, chan):
+		for symbol in self.zctrls[chan]:
+			self.midi_unlearn(self.zctrls[chan][symbol])
+
 #-------------------------------------------------------------------------------

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -1313,20 +1313,17 @@ class zynthian_gui:
 
 
 	def cuia_learn(self, params=None):
-		try:
-			self.screens[self.current_screen].start_midi_learn()
-		except:
-			if not self.is_shown_alsa_mixer():
-				if self.current_screen == "zs3_learn":
-					self.close_screen()
-				elif self.current_screen != "control":
-					self.show_screen_reset("control")
-				else:
-					if zynthian_gui_config.midi_prog_change_zs3 and (self.midi_learn_mode or self.midi_learn_zctrl):
-						self.show_screen("zs3_learn")
-						return
+		if not self.is_shown_alsa_mixer():
+			if self.current_screen == "zs3_learn":
+				self.close_screen()
+			elif self.current_screen != "control":
+				self.show_screen_reset("control")
+			else:
+				if zynthian_gui_config.midi_prog_change_zs3 and (self.midi_learn_mode or self.midi_learn_zctrl):
+					self.show_screen("zs3_learn")
+					return
 
-			self.enter_midi_learn_mode()
+		self.enter_midi_learn_mode()
 
 
 	def cuia_bank_preset(self, params=None):

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -5,7 +5,7 @@
 #
 # Main Class and Program for Zynthian GUI
 #
-# Copyright (C) 2015-2016 Fernando Moyano <jofemodo@zynthian.org>
+# Copyright (C) 2015-2022 Fernando Moyano <jofemodo@zynthian.org>
 #
 #******************************************************************************
 #
@@ -49,6 +49,7 @@ import zynautoconnect
 from zyncoder.zyncore import lib_zyncore
 from zynlibs.zynmixer import zynmixer
 from zynlibs.zynaudioplayer import zynaudioplayer
+from zynlibs.zynseq import zynseq
 
 from zyngine import zynthian_zcmidi
 from zyngine import zynthian_midi_filter
@@ -957,6 +958,15 @@ class zynthian_gui:
 		return zynthian_gui_config.midi_single_active_channel
 
 
+	def clean_all(self):
+		if len(self.screens['layer'].layers) > 0:
+			self.screens['snapshot'].save_last_state_snapshot()
+		self.screens['layer'].reset()
+		self.zynmixer.reset_state()
+		zynseq.load("")
+		self.show_screen_reset('main')
+
+
 	def start_audio_player(self):
 		filename = self.audio_recorder.filename
 		if not filename or not os.path.exists(filename):
@@ -1032,6 +1042,10 @@ class zynthian_gui:
 			self.all_sounds_off()
 			sleep(0.1)
 			self.raw_all_notes_off()
+		
+		elif cuia == "CLEAN_ALL" and params == ['CONFIRM']:
+			self.clean_all()
+			self.show_screen_reset('Audio audio_mixer') #TODO: Should send signal so that UI can react
 
 		#----------------------------------------------------------------
 		# Audio & MIDI Recording/Playback actions

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -1152,53 +1152,57 @@ class zynthian_gui:
 		# Rotary Control => it receives the zynpot number as paramter
 		#----------------------------------------------------------------
 		elif cuia == "ZYNPOT_UP":
-			#TODO
-			pass
+			try:
+				self.get_current_screen_obj().zynpot_cb(params[0], 1)
+			except:
+				pass
 		elif cuia == "ZYNPOT_DOWN":
-			#TODO
-			pass
+			try:
+				self.get_current_screen_obj().zynpot_cb(params[0], -1)
+			except:
+				pass
 
 		#----------------------------------------------------------------
 		# Legacy "4 x rotaries" CUIAs
 		#----------------------------------------------------------------
 		elif cuia == "SELECT_UP":
 			try:
-				self.get_current_screen_obj().select_up()
+				self.get_current_screen_obj().zynpot_cb(zynthian_gui_config.ENC_SELECT, 1)
 			except:
 				pass
 		elif cuia == "SELECT_DOWN":
 			try:
-				self.get_current_screen_obj().select_down()
+				self.get_current_screen_obj().zynpot_cb(zynthian_gui_config.ENC_SELECT, -1)
 			except:
 				pass
 		elif cuia == "BACK_UP":
 			try:
-				self.get_current_screen_obj().back_up()
+				self.get_current_screen_obj().zynpot_cb(zynthian_gui_config.ENC_BACK, 1)
 			except:
 				pass
 		elif cuia == "BACK_DOWN":
 			try:
-				self.get_current_screen_obj().back_down()
+				self.get_current_screen_obj().zynpot_cb(zynthian_gui_config.ENC_BACK, -1)
 			except:
 				pass
 		elif cuia == "LAYER_UP":
 			try:
-				self.get_current_screen_obj().layer_up()
+				self.get_current_screen_obj().zynpot_cb(zynthian_gui_config.ENC_LAYER, 1)
 			except:
 				pass
 		elif cuia == "LAYER_DOWN":
 			try:
-				self.get_current_screen_obj().layer_down()
+				self.get_current_screen_obj().zynpot_cb(zynthian_gui_config.ENC_LAYER, -1)
 			except:
 				pass
 		elif cuia in ("SNAPSHOT_UP", "LEARN_UP"):
 			try:
-				self.get_current_screen_obj().snapshot_up()
+				self.get_current_screen_obj().zynpot_cb(zynthian_gui_config.ENC_SNAPSHOT, 1)
 			except:
 				pass
 		elif cuia in ("SNAPSHOT_DOWN", "LEARN_DOWN"):
 			try:
-				self.get_current_screen_obj().snapshot_down()
+				self.get_current_screen_obj().zynpot_cb(zynthian_gui_config.ENC_SNAPSHOT, -1)
 			except:
 				pass
 

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -1234,6 +1234,13 @@ class zynthian_gui:
 		# Screen/Mode management CUIAs
 		#----------------------------------------------------------------
 		#TODO: Toggle not necessarily desired action. Should we add set-screen options?
+
+		elif cuia == "TOGGLE_VIEW" and params:
+			self.toggle_screen(params[0])
+
+		elif cuia == "SHOW_VIEW" and params:
+			self.show_screen_reset(params[0])
+		
 		elif cuia in ("MODAL_MAIN", "SCREEN_MAIN"):
 			self.toggle_screen("main")
 

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -1544,7 +1544,7 @@ class zynthian_gui:
 			self.back_screen()
 
 		elif i==2:
-			self.cuia_learn()
+			pass
 
 		elif i==3:
 			self.screens[self.current_screen].switch_select('S')

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -183,6 +183,7 @@ class zynthian_gui:
 	}
 
 	def __init__(self):
+		self.test_mode = False
 		self.screens = {}
 		self.screen_history = []
 		self.current_screen = None
@@ -1011,7 +1012,11 @@ class zynthian_gui:
 		#----------------------------------------------------------------
 		# System actions
 		#----------------------------------------------------------------
-		if cuia == "POWER_OFF":
+		if cuia == "TEST_MODE":
+			self.test_mode = params
+			logging.warning('TEST_MODE: {}'.format(params))
+
+		elif cuia == "POWER_OFF":
 			self.screens['admin'].power_off_confirmed()
 
 		elif cuia == "REBOOT":
@@ -1045,7 +1050,7 @@ class zynthian_gui:
 		
 		elif cuia == "CLEAN_ALL" and params == ['CONFIRM']:
 			self.clean_all()
-			self.show_screen_reset('Audio audio_mixer') #TODO: Should send signal so that UI can react
+			self.show_screen_reset('main') #TODO: Should send signal so that UI can react
 
 		#----------------------------------------------------------------
 		# Audio & MIDI Recording/Playback actions

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -48,7 +48,6 @@ import zynconf
 import zynautoconnect
 from zyncoder.zyncore import lib_zyncore
 from zynlibs.zynmixer import zynmixer
-from zynlibs.zynmixer.zynmixer import lib_zynmixer
 from zynlibs.zynaudioplayer import zynaudioplayer
 
 from zyngine import zynthian_zcmidi
@@ -528,7 +527,7 @@ class zynthian_gui:
 			if part2 in ("HEARTBEAT", "SETUP"):
 				if src.hostname not in self.osc_clients:
 					try:
-						lib_zynmixer.addOscClient(ctypes.c_char_p(src.hostname.encode('utf-8')))
+						self.zynmixer.addOscClient(ctypes.c_char_p(src.hostname.encode('utf-8')))
 					except:
 						logging.warning("Failed to add OSC client registration %s", src.hostname)
 				self.osc_clients[src.hostname] = monotonic()
@@ -549,6 +548,7 @@ class zynthian_gui:
 
 		# Create global objects first
 		self.audio_recorder = zynthian_audio_recorder()
+		self.zynmixer = zynmixer.zynmixer()
 
 		# Create Core UI Screens
 		self.screens['info'] = zynthian_gui_info()
@@ -583,7 +583,7 @@ class zynthian_gui:
 		self.screens['midi_recorder'] = zynthian_gui_midi_recorder()
 		self.screens['stepseq'] = zynthian_gui_stepsequencer()
 		self.screens['touchscreen_calibration'] = zynthian_gui_touchscreen_calibration()
-
+		
 		# Init Auto-connector
 		zynautoconnect.start()
 
@@ -1897,10 +1897,10 @@ class zynthian_gui:
 				self.status_info['cpu_load'] = zynautoconnect.get_jackd_cpu_load()
 			else:
 				# Get audio peak level
-				self.status_info['peakA'] = lib_zynmixer.getDpm(MIXER_MAIN_CHANNEL, 0)
-				self.status_info['peakB'] = lib_zynmixer.getDpm(MIXER_MAIN_CHANNEL, 1)
-				self.status_info['holdA'] = lib_zynmixer.getDpmHold(MIXER_MAIN_CHANNEL, 0)
-				self.status_info['holdB'] = lib_zynmixer.getDpmHold(MIXER_MAIN_CHANNEL, 1)
+				self.status_info['peakA'] = self.zynmixer.get_dpm(MIXER_MAIN_CHANNEL, 0)
+				self.status_info['peakB'] = self.zynmixer.get_dpm(MIXER_MAIN_CHANNEL, 1)
+				self.status_info['holdA'] = self.zynmixer.get_dpm_hold(MIXER_MAIN_CHANNEL, 0)
+				self.status_info['holdB'] = self.zynmixer.get_dpm_hold(MIXER_MAIN_CHANNEL, 1)
 
 			# Get Status Flags (once each 5 refreshes)
 			if self.status_counter>5:
@@ -2017,7 +2017,7 @@ class zynthian_gui:
 			if self.osc_clients[client] < self.watchdog_last_check - self.osc_heartbeat_timeout:
 				self.osc_clients.pop(client)
 				try:
-					lib_zynmixer.removeOscClient(ctypes.c_char_p(client.encode('utf-8')))
+					self.zynmixer.removeOscClient(ctypes.c_char_p(client.encode('utf-8')))
 				except:
 					pass
 		# Poll

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -866,8 +866,7 @@ class zynthian_gui:
 		self.midi_learn_mode = True
 		self.midi_learn_zctrl = None
 		lib_zyncore.set_midi_learning_mode(1)
-		self.screens['control'].refresh_midi_bind()
-		self.screens['control'].set_select_path()
+		self.screens[self.current_screen].start_midi_learn()
 		#self.show_screen('zs3_learn')
 
 
@@ -875,9 +874,8 @@ class zynthian_gui:
 		self.midi_learn_mode = False
 		self.midi_learn_zctrl = None
 		lib_zyncore.set_midi_learning_mode(0)
-		self.screens['control'].refresh_midi_bind()
-		self.screens['control'].set_select_path()
-		self.show_current_screen()
+		self.screens[self.current_screen].end_midi_learn()
+		#self.show_current_screen()
 
 
 	def show_control_xy(self, xctrl, yctrl):


### PR DESCRIPTION
Implements MIDI-learn for mixer. Due to button conflicts, the learn mode is enabled with bold BACK press. It may be worth reviewing how we trigger learn (which might benefit from being less easily triggered to reduce risk of accidentally entering learn mode during performance).
There are other enhancements and fixes in the branch discovered during dev progress - see commit comments for details.