### PR TITLE
Fix ZS3, snapshot save for layers with no midi channel

### DIFF
--- a/zyngine/zynthian_layer.py
+++ b/zyngine/zynthian_layer.py
@@ -588,7 +588,7 @@ class zynthian_layer:
 				logging.debug("Saving {}".format(k))
 				zs3['controllers_dict'][k] = self.controllers_dict[k].get_snapshot()
 
-			if self.midi_chan>=0:
+			if self.midi_chan is not None and self.midi_chan>=0:
 				zs3['note_range'] = {
 					'note_low': zyncoder.lib_zyncoder.get_midi_filter_note_low(self.midi_chan),
 					'note_high': zyncoder.lib_zyncoder.get_midi_filter_note_high(self.midi_chan),
@@ -637,7 +637,7 @@ class zynthian_layer:
 				self.controllers_dict[k].restore_snapshot(zs3['controllers_dict'][k])
 
 			# Set Note Range
-			if self.midi_chan>=0 and 'note_range' in zs3:
+			if self.midi_chan is not None and self.midi_chan>=0 and 'note_range' in zs3:
 				nr = zs3['note_range']
 				zyncoder.lib_zyncoder.set_midi_filter_note_range(self.midi_chan, nr['note_low'], nr['note_high'], nr['octave_trans'], nr['halftone_trans'])
 

--- a/zyngui/zynthian_gui_layer.py
+++ b/zyngui/zynthian_gui_layer.py
@@ -53,13 +53,13 @@ class zynthian_gui_layer(zynthian_gui_selector):
 		self.replace_layer_index = None
 		self.layer_chain_parallel = False
 		self.last_snapshot_fpath = None
-		self.last_zs3_index = [0] * 16; # Last selected ZS3 snapshot, per MIDI channel
+		self.last_zs3_index = [0] * 17; # Last selected ZS3 snapshot, per MIDI channel, last item for no MIDI channel
 		super().__init__('Layer', True)
 		self.create_amixer_layer()
-		
+
 
 	def reset(self):
-		self.last_zs3_index = [0] * 16; # Last selected ZS3 snapshot, per MIDI channel
+		self.last_zs3_index = [0] * 17; # Last selected ZS3 snapshot, per MIDI channel, last item for no MIDI channel
 		self.show_all_layers = False
 		self.add_layer_eng = None
 		self.last_snapshot_fpath = None
@@ -545,7 +545,7 @@ class zynthian_gui_layer(zynthian_gui_selector):
 		for layer in self.layers:
 			if zynthian_gui_config.midi_single_active_channel or midich==layer.get_midi_chan():
 				if layer.restore_zs3(zs3_index) and not selected:
-					self.last_zs3_index[midich] = zs3_index
+					self.last_zs3_index[midich is None and 16 or midich] = zs3_index
 					try:
 						if not self.zyngui.modal_screen and self.zyngui.active_screen not in ('main','layer'):
 							self.select_action(self.root_layers.index(layer))
@@ -555,7 +555,7 @@ class zynthian_gui_layer(zynthian_gui_selector):
 
 
 	def get_last_zs3_index(self, midich):
-		return self.last_zs3_index[midich]
+		return self.last_zs3_index[midich is None and 16 or midich]
 
 
 	def save_midi_chan_zs3(self, midich, zs3_index):

--- a/zyngui/zynthian_gui_snapshot.py
+++ b/zyngui/zynthian_gui_snapshot.py
@@ -140,7 +140,7 @@ class zynthian_gui_snapshot(zynthian_gui_selector):
 
 	def get_new_snapshot(self):
 		parts = self.zyngui.screens['layer'].layers[0].get_presetpath().split('#',2)
-		name = parts[1].replace("/",";").replace(">",";").replace(" ; ",";")
+		name = parts[-1].replace("/",";").replace(">",";").replace(" ; ",";")
 		return self.get_next_name() + '-' + name + '.zss'
 
 


### PR DESCRIPTION
Not all layers have MIDI channels (mod-ui) but the following features are
making assumptions that the layer midi channel number will not be null:
- Snapshot save
- ZS3 program change learn
- ZS3 program change recall

This change fixes these features for the mod-ui engine by allowing for
None midi channel numbers.

This is a stable-only change to fix broken features for the mod-ui engine. ZS3 has been significantly reworked in testing and likely doesn't have these issues.