### PR TITLE
Fix zynthian/zynthian-issue-tracking#817: Fix preset restore after preload,

### DIFF
--- a/zyngui/zynthian_gui_layer.py
+++ b/zyngui/zynthian_gui_layer.py
@@ -113,6 +113,11 @@ class zynthian_gui_layer(zynthian_gui_selector):
 			self.layer_options()
 
 
+	def restore_presets(self):
+		for layer in self.layers:
+			layer.restore_preset()
+
+
 	def create_amixer_layer(self):
 		mixer_eng = self.zyngui.screens['engine'].start_engine('MX')
 		self.amixer_layer = zynthian_layer(mixer_eng, None, self.zyngui)

--- a/zyngui/zynthian_gui_preset.py
+++ b/zyngui/zynthian_gui_preset.py
@@ -164,8 +164,6 @@ class zynthian_gui_preset(zynthian_gui_selector):
 			if t == 'B':
 				self.show_preset_options()
 				return True
-
-		self.restore_preset()
 		return False
 
 

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -721,6 +721,9 @@ class zynthian_gui:
 			else:
 				return
 
+		if screen not in ("bank", "preset", "option"):
+			self.screens['layer'].restore_presets()
+
 		self.screens[screen].build_view()
 		self.hide_screens(exclude=screen)
 		if hmode == zynthian_gui.SCREEN_HMODE_ADD:
@@ -1113,7 +1116,7 @@ class zynthian_gui:
 	# -------------------------------------------------------------------
 
 	def callable_ui_action(self, cuia, params=None):
-		logging.debug("CUIA '{}' => {}".format(cuia,params))
+		logging.debug("CUIA '{}' => {}".format(cuia, params))
 
 		#----------------------------------------------------------------
 		# System actions


### PR DESCRIPTION
so it's always done after exiting preset/bank screen.