### PR TITLE
Move code to generate controller screen to engine from JALV.

### DIFF
--- a/zyngine/zynthian_controller.py
+++ b/zyngine/zynthian_controller.py
@@ -57,7 +57,7 @@ class zynthian_controller:
 		self.is_integer = True # True if control is Integer
 		self.is_logarithmic = False # True if control uses logarithmic scale
 		self.is_dirty = True # True if control value changed since last UI update
-		self.not_on_gui = True # True to hint to GUI to show control
+		self.not_on_gui = False # True to hint to GUI to show control
 		self.display_priority = 0 # Hint of order in which to display control (higher comes first)
 
 		# Parameters to send values if dedciated engine send method not available

--- a/zyngine/zynthian_engine.py
+++ b/zyngine/zynthian_engine.py
@@ -66,6 +66,7 @@ class zynthian_basic_engine:
 		self.command_env = os.environ.copy()
 		self.command_prompt = prompt
 		self.command_cwd = cwd
+		self.ignore_not_on_gui = False
 
 	def __del__(self):
 		self.stop()
@@ -604,27 +605,53 @@ class zynthian_engine(zynthian_basic_engine):
 		return zctrls
 
 
+	def get_ctrl_screen_name(self, gname, i):
+		if i > 0:
+			gname = "{}#{}".format(gname, i)
+		return gname
+
+
 	def generate_ctrl_screens(self, zctrl_dict):
 		if self._ctrl_screens is None:
 			self._ctrl_screens = []
 
-		c = 1
-		ctrl_set = []
+		# Get zctrls by group
+		zctrl_group = OrderedDict()
 		for symbol, zctrl in zctrl_dict.items():
-			try:
-				#logging.debug("CTRL {}".format(symbol))
-				ctrl_set.append(symbol)
-				if len(ctrl_set) >= 4:
-					#logging.debug("ADDING CONTROLLER SCREEN {}#{}".format(self.nickname,c))
-					self._ctrl_screens.append(["{}#{}".format(self.nickname, c), ctrl_set])
-					ctrl_set=[]
-					c = c + 1
-			except Exception as err:
-				logging.error("Generating Controller Screens => {}".format(err))
+			gsymbol = zctrl.group_symbol
+			if gsymbol not in zctrl_group:
+				if zctrl.group_name:
+					zctrl_group[gsymbol] = [zctrl.group_name, OrderedDict()]
+				else:
+					zctrl_group[gsymbol] = [zctrl.group_symbol, OrderedDict()]
+			zctrl_group[gsymbol][1][symbol] = zctrl
+		if None in zctrl_group:
+			zctrl_group[None][0] = "Ctrls"
 
-		if len(ctrl_set) >= 1:
-			#logging.debug("ADDING CONTROLLER SCREEN #"+str(c))
-			self._ctrl_screens.append(["{}#{}".format(self.nickname, c), ctrl_set])
+		for gsymbol, gdata in zctrl_group.items():
+			ctrl_set = []
+			gname = gdata[0]
+			if len(gdata[1]) <= 4:
+				c = 0
+			else:
+				c = 1
+			for symbol, zctrl in gdata[1].items():
+				try:
+					if not self.ignore_not_on_gui and zctrl.not_on_gui:
+						continue
+					#logging.debug("CTRL {}".format(symbol))
+					ctrl_set.append(symbol)
+					if len(ctrl_set) >= 4:
+						#logging.debug("ADDING CONTROLLER SCREEN {}".format(self.get_ctrl_screen_name(gname,c)))
+						self._ctrl_screens.append([self.get_ctrl_screen_name(gname,c),ctrl_set])
+						ctrl_set = []
+						c = c + 1
+				except Exception as err:
+					logging.error("Generating Controller Screens => {}".format(err))
+
+			if len(ctrl_set) >= 1:
+				#logging.debug("ADDING CONTROLLER SCREEN {}",format(self.get_ctrl_screen_name(gname,c)))
+				self._ctrl_screens.append([self.get_ctrl_screen_name(gname,c),ctrl_set])
 
 
 	def send_controller_value(self, zctrl):

--- a/zyngine/zynthian_engine_jalv.py
+++ b/zyngine/zynthian_engine_jalv.py
@@ -631,60 +631,6 @@ class zynthian_engine_jalv(zynthian_engine):
 		return self.lv2_monitors_dict
 
 
-	def get_ctrl_screen_name(self, gname, i):
-		if i > 0:
-			gname = "{}#{}".format(gname, i)
-		return gname
-
-
-	def generate_ctrl_screens(self, zctrl_dict):
-		if self._ctrl_screens is None:
-			self._ctrl_screens = []
-
-		# Get zctrls by group
-		zctrl_group = OrderedDict()
-		for symbol, zctrl in zctrl_dict.items():
-			gsymbol = zctrl.group_symbol
-			if gsymbol is None:
-				gsymbol = "_"
-			if gsymbol not in zctrl_group:
-				zctrl_group[gsymbol] = [zctrl.group_name, OrderedDict()]
-			zctrl_group[gsymbol][1][symbol] = zctrl
-		if "_" in zctrl_group:
-			last_group = zctrl_group["_"]
-			del zctrl_group["_"]
-			if len(zctrl_group) == 0:
-				last_group[0] = "Ctrls"
-			else:
-				last_group[0] = "Uncategorised"
-			zctrl_group["_"] = last_group
-
-		for gsymbol, gdata in zctrl_group.items():
-			ctrl_set = []
-			gname = gdata[0]
-			if len(gdata[1]) <= 4:
-				c = 0
-			else:
-				c = 1
-			for symbol, zctrl in gdata[1].items():
-				try:
-					if not self.ignore_not_on_gui and zctrl.not_on_gui:
-						continue
-					#logging.debug("CTRL {}".format(symbol))
-					ctrl_set.append(symbol)
-					if len(ctrl_set) >= 4:
-						#logging.debug("ADDING CONTROLLER SCREEN {}".format(self.get_ctrl_screen_name(gname,c)))
-						self._ctrl_screens.append([self.get_ctrl_screen_name(gname,c),ctrl_set])
-						ctrl_set = []
-						c = c + 1
-				except Exception as err:
-					logging.error("Generating Controller Screens => {}".format(err))
-
-			if len(ctrl_set) >= 1:
-				#logging.debug("ADDING CONTROLLER SCREEN {}",format(self.get_ctrl_screen_name(gname,c)))
-				self._ctrl_screens.append([self.get_ctrl_screen_name(gname,c),ctrl_set])
-
-
 	def get_controllers_dict(self, layer):
 		# Get plugin static controllers
 		zctrls = super().get_controllers_dict(layer)


### PR DESCRIPTION
Any engine can benefit from this function.
Facilitates Pianoteq enhancements.
not_on_gui default changes to True (MX beneifits from this). Undefined controller groups now use name "Ctrls" (was "Uncategorised"). Control groups built in order (previously uncatagorised were moved to end).