### PR TITLE
Prefer preset UID to name when loading snapshot

### DIFF
--- a/zyngine/zynthian_layer.py
+++ b/zyngine/zynthian_layer.py
@@ -602,7 +602,10 @@ class zynthian_layer:
 
 		#  and set preset
 		try:
-			self.preset_loaded = self.set_preset_by_name(state['preset_name'], True, False)
+			if(state['preset_info']):
+				self.preset_loaded = self.set_preset_by_id(state['preset_info'][0], True, False)
+			else:
+				self.preset_loaded = self.set_preset_by_name(state['preset_name'], True, False)
 			self.wait_stop_loading()
 		except Exception as e:
 			logging.warning("Invalid Preset on layer {}: {}".format(self.get_basepath(), e))


### PR DESCRIPTION
This fixes some snapshot loading compatibility issues.
Prefer preset UID if available else use old behaviour (name).