### PR TITLE
modui: Use ~/.pedalboards/ for the bundlepath.

### DIFF
--- a/zyngine/zynthian_engine_modui.py
+++ b/zyngine/zynthian_engine_modui.py
@@ -85,6 +85,10 @@ class zynthian_engine_modui(zynthian_engine):
 		self.start()
 
 
+	def __del__(self):
+		pass
+
+
 	def reset(self):
 		super().reset()
 		self.graph = {}

--- a/zyngine/zynthian_engine_modui.py
+++ b/zyngine/zynthian_engine_modui.py
@@ -55,7 +55,8 @@ class zynthian_engine_modui(zynthian_engine):
 
 	bank_dirs = [
 		('EX', zynthian_engine.ex_data_dir + "/presets/mod-ui/pedalboards"),
-		('_', zynthian_engine.my_data_dir + "/presets/mod-ui/pedalboards")
+		# this is a symlink to zynthian_engine.my_data_dir + "/presets/mod-ui/pedalboards"
+		('_', os.path.expanduser("~/.pedalboards/"))
 	]
 
 	# ---------------------------------------------------------------------------


### PR DESCRIPTION
~/.pedalboards/ is a symlink to
/zynthian/zynthian-my-data/presets/mod-ui/pedalboards, but the mod-ui save method has conditionals[1] which force saving as a unique name unless the bundlepath matches the configured path. This makes it hard to make changes to existing zynthian snapshots since the pedalboard name is always changing.

This change switches the path in the engine to the path mod-ui is configured for. Alternately we could carry a mod-ui patch to change the default[2] but that might be harder to maintain.

[1] https://github.com/zynthian/mod-ui/blob/master/mod/host.py#L2264
[2] https://github.com/zynthian/mod-ui/blob/master/mod/settings.py#L55