### PR TITLE
Add stutter effect to step sequencer.

### DIFF
--- a/zyngui/zynthian_gui_patterneditor.py
+++ b/zyngui/zynthian_gui_patterneditor.py
@@ -230,6 +230,8 @@ class zynthian_gui_patterneditor(zynthian_gui_base.zynthian_gui_base):
 			options['[X] Metronome'] = 'Metronome'
 		else:
 			options['[  ] Metronome'] = 'Metronome'
+		options['Stutter count'] = 'Stutter count'
+		options['Stutter duration'] = 'Stutter duration'
 		options['Metronome volume ({})'.format(int(100 * self.zyngui.zynseq.libseq.getMetronomeVolume()))] = 'Metronome volume'
 		options['Beats in pattern ({})'.format(self.zyngui.zynseq.libseq.getBeatsInPattern())] = 'Beats in pattern'
 		options['Steps per beat ({})'.format(self.zyngui.zynseq.libseq.getStepsPerBeat())] = 'Steps per beat'
@@ -262,11 +264,19 @@ class zynthian_gui_patterneditor(zynthian_gui_base.zynthian_gui_base):
 			self.close_screen()
 
 
+	def get_note_from_row(self, row):
+		return self.keymap[row]["note"]
+
+
 	def menu_cb(self, option, params):
 		if params == 'Tempo':
 			self.enable_param_editor(self, 'tempo', 'Tempo', {'value_min':10, 'value_max':420, 'value_default':120, 'is_integer':False, 'nudge_factor':0.1, 'value':self.zyngui.zynseq.libseq.getTempo()})
 		elif params == 'Beats per bar':
 			self.enable_param_editor(self, 'bpb', 'Beats per bar', {'value_min':1, 'value_max':64, 'value_default':4, 'value':self.zyngui.zynseq.libseq.getBeatsPerBar()})
+		elif params == 'Stutter count':
+			self.enable_param_editor(self, 'stutter_count', 'Stutter Count', {'value_min':0, 'value_max':12, 'value_default':0, 'value':self.zyngui.zynseq.libseq.getStutterCount(self.selected_cell[0], self.get_note_from_row(self.selected_cell[1]))})
+		elif params == 'Stutter duration':
+			self.enable_param_editor(self, 'stutter_dur', 'Stutter Duration', {'value_min':1, 'value_max':96, 'value_default':0, 'value':self.zyngui.zynseq.libseq.getStutterDur(self.selected_cell[0], self.get_note_from_row(self.selected_cell[1]))})
 		elif params == 'Metronome':
 			self.zyngui.zynseq.libseq.enableMetronome(not self.zyngui.zynseq.libseq.isMetronomeEnabled())
 		elif params == 'Metronome volume':
@@ -308,10 +318,14 @@ class zynthian_gui_patterneditor(zynthian_gui_base.zynthian_gui_base):
 	def send_controller_value(self, zctrl):
 		if zctrl.symbol == 'tempo':
 			self.zyngui.zynseq.libseq.setTempo(zctrl.value)
-		if zctrl.symbol == 'metro_vol':
+		elif zctrl.symbol == 'metro_vol':
 			self.zyngui.zynseq.libseq.setMetronomeVolume(zctrl.value / 100.0)
-		if zctrl.symbol == 'bpb':
+		elif zctrl.symbol == 'bpb':
 			self.zyngui.zynseq.libseq.setBeatsPerBar(zctrl.value)
+		elif zctrl.symbol == 'stutter_count':
+			self.zyngui.zynseq.libseq.setStutterCount(self.selected_cell[0], self.get_note_from_row(self.selected_cell[1]), zctrl.value)
+		elif zctrl.symbol == 'stutter_dur':
+			self.zyngui.zynseq.libseq.setStutterDur(self.selected_cell[0], self.get_note_from_row(self.selected_cell[1]), zctrl.value)
 		elif zctrl.symbol == 'copy':
 			self.load_pattern(zctrl.value)
 		elif zctrl.symbol == 'transpose':

--- a/zynlibs/zynseq/file_format.txt
+++ b/zynlibs/zynseq/file_format.txt
@@ -1,6 +1,6 @@
 zynseq file format (RIFF)
 =========================
-Version 7
+Version 8
 Pattern time is measured in steps.
 Sequence time is measured in MIDI clock cycles.
 
@@ -37,6 +37,8 @@ Block:
 		Value 2 start [1]
 		Value 1 end [1]
 		Value 2 end [1]
+		Stutter count [1]
+		Stutter duration [1]
 		Unused padding [1] = 0
 
 RIFF Header:

--- a/zynlibs/zynseq/pattern.cpp
+++ b/zynlibs/zynseq/pattern.cpp
@@ -159,6 +159,8 @@ uint8_t Pattern::getStutterCount(uint32_t step, uint8_t note)
 
 void Pattern::setStutterCount(uint32_t step, uint8_t note, uint8_t count)
 {
+    if(count > MAX_STUTTER_COUNT)
+        return;
     for(StepEvent* ev : m_vEvents)
     {
         if(ev->getPosition() == step && ev->getCommand() == MIDI_NOTE_ON && ev->getValue1start() == note)
@@ -180,6 +182,8 @@ uint8_t Pattern::getStutterDur(uint32_t step, uint8_t note)
 
 void Pattern::setStutterDur(uint32_t step, uint8_t note, uint8_t dur)
 {
+    if(dur > MAX_STUTTER_DUR)
+        return;
     for(StepEvent* ev : m_vEvents)
         if(ev->getPosition() == step && ev->getCommand() == MIDI_NOTE_ON && ev->getValue1start() == note)
         {
@@ -396,6 +400,36 @@ void Pattern::changeDurationAll(float value)
         if(duration < 0.1) //!@todo How short should we allow duration change?
             duration = 0.1;
         ev->setDuration(duration);
+    }
+}
+
+void Pattern::changeStutterCountAll(int value)
+{
+    for(StepEvent* ev : m_vEvents)
+    {
+        if(ev->getCommand() != MIDI_NOTE_ON)
+            continue;
+        int count = ev->getStutterCount() + value;
+        if(count < 0)
+            count = 0;
+        if(count > 255)
+            count = 255;
+        ev->setStutterCount(count);
+    }
+}
+
+void Pattern::changeStutterDurAll(int value)
+{
+    for(StepEvent* ev : m_vEvents)
+    {
+        if(ev->getCommand() != MIDI_NOTE_ON)
+            continue;
+        int dur = ev->getStutterDur() + value;
+        if(dur < 1)
+            dur = 1;
+        if(dur > 255)
+            dur = 255;
+        ev->setStutterDur(dur);
     }
 }
 

--- a/zynlibs/zynseq/pattern.h
+++ b/zynlibs/zynseq/pattern.h
@@ -4,6 +4,9 @@
 #include <vector>
 #include <memory>
 
+#define MAX_STUTTER_COUNT 32
+#define MAX_STUTTER_DUR 96
+
 /** StepEvent class provides an individual step event .
 *   The event may be part of a song, pattern or sequence. Events do not have MIDI channel which is applied by the function to play the event, e.g. pattern player assigned to specific channel. Events have the concept of position which is an offset from some epoch measured in steps. The epoch depends on the function using the event, e.g. pattern player may use start of pattern as epoch (position = 0). There is a starting and end value to allow interpolation of MIDI events between the start and end positions.
 */
@@ -309,6 +312,16 @@ class Pattern
         *   @param  value Offset to adjust +/-100.0 or whatever
         */
         void changeDurationAll(float value);
+
+        /** @brief  Change stutter count of all notes in patterm
+        *   @param  value Offset to adjust +/-100 or whatever
+        */
+        void changeStutterCountAll(int value);
+
+        /** @brief  Change stutter dur of all notes in patterm
+        *   @param  value Offset to adjust +/-100 or whatever
+        */
+        void changeStutterDurAll(int value);
 
         /** @brief  Clear all events from pattern
         */

--- a/zynlibs/zynseq/pattern.h
+++ b/zynlibs/zynseq/pattern.h
@@ -21,6 +21,8 @@ class StepEvent
             m_nValue2start = 100;
             m_nValue1end = 60;
             m_nValue2end = 0;
+            m_nStutterCount = 0;
+            m_nStutterDur = 1;
         };
 
         /** Constructor - create an instance of StepEvent object
@@ -37,7 +39,10 @@ class StepEvent
                 m_nValue2end = 0;
             else
                 m_nValue2end = value2;
+            m_nStutterCount = 0;
+            m_nStutterDur = 1;
         };
+
         /** Copy constructor - create an copy of StepEvent object from an existing object
         */
         StepEvent(StepEvent* pEvent)
@@ -49,7 +54,10 @@ class StepEvent
             m_nValue2start = pEvent->getValue2start();
             m_nValue1end = pEvent->getValue1end();
             m_nValue2end = pEvent->getValue2end();
+            m_nStutterCount = pEvent->getStutterCount();
+            m_nStutterDur = pEvent->getStutterDur();
         };
+
         uint32_t getPosition() { return m_nPosition; };
         float getDuration() { return m_fDuration; };
         uint8_t getCommand() { return m_nCommand; };
@@ -57,12 +65,17 @@ class StepEvent
         uint8_t getValue2start() { return m_nValue2start; };
         uint8_t getValue1end() { return m_nValue1end; };
         uint8_t getValue2end() { return m_nValue2end; };
+        uint8_t getStutterCount() { return m_nStutterCount; };
+        uint8_t getStutterDur() { return m_nStutterDur; };
         void setPosition(uint32_t position) { m_nPosition = position; };
         void setDuration(float duration) { m_fDuration = duration; };
         void setValue1start(uint8_t value) { m_nValue1start = value; };
         void setValue2start(uint8_t value) { m_nValue2start = value; };
         void setValue1end(uint8_t value) { m_nValue1end = value; };
         void setValue2end(uint8_t value) { m_nValue2end = value; };
+        void setStutterCount(uint8_t value) { m_nStutterCount = value; };
+        void setStutterDur(uint8_t value) { if (value) m_nStutterDur = value; };
+
     private:
         uint32_t m_nPosition; // Start position of event in steps
         float m_fDuration; // Duration of event in steps
@@ -72,6 +85,8 @@ class StepEvent
         uint8_t m_nValue1end; // MIDI value 1 at end of event
         uint8_t m_nValue2end; // MIDI value 2 at end of event
         uint32_t m_nProgress; // Progress through event (start value to end value)
+        uint8_t m_nStutterCount; // Quantity of stutters (fast repeats) at start of event
+        uint8_t m_nStutterDur; // Duration of each stutter in clock cycles
 };
 
 /**    Pattern class provides a group of MIDI events within period of time
@@ -146,6 +161,42 @@ class Pattern
         *   @retval float Duration of note or 0 if note does not exist
         */
         float getNoteDuration(uint32_t step, uint8_t note);
+
+        /** @brief  Set note stutter
+        *   @param  position Quantity of steps from start of pattern at which note starts
+        *   @param  note MIDI note number
+        *   @param  count Quantity of stutters
+        *   @param  dur Length of each stutter in clock cycles (min=1)
+        */
+        void setStutter(uint32_t step, uint8_t note, uint8_t count, uint8_t dur);
+
+        /** @brief  Set note stutter count
+        *   @param  position Quantity of steps from start of pattern at which note starts
+        *   @param  note MIDI note number
+        *   @param  count Quantity of stutters
+        */
+        void setStutterCount(uint32_t step, uint8_t note, uint8_t count);
+
+        /** @brief  Set note stutter duration
+        *   @param  position Quantity of steps from start of pattern at which note starts
+        *   @param  note MIDI note number
+        *   @param  dur Length of each stutter in clock cycles (min=1)
+        */
+        void setStutterDur(uint32_t step, uint8_t note, uint8_t dur);
+
+        /** @brief  Get note stutter duration
+        *   @param  position Quantity of steps from start of pattern at which note starts
+        *   @param  note MIDI note number
+        *   @retval uint8_t Duration of stutter each stutter in clock cycles
+        */
+        uint8_t getStutterCount(uint32_t step, uint8_t note);
+
+        /** @brief  Get note stutter count
+        *   @param  position Quantity of steps from start of pattern at which note starts
+        *   @param  note MIDI note number
+        *   @retval uint8_t Quantity of stutter repeats at start of note
+        */
+        uint8_t getStutterDur(uint32_t step, uint8_t note);
 
         /** @brief  Add program change to pattern
         *   @param  position Quantity of steps from start of pattern at which to add program change
@@ -300,7 +351,7 @@ class Pattern
     private:
         void deleteEvent(uint32_t position, uint8_t command, uint8_t value1);
 
-        std::vector<StepEvent> m_vEvents; // Vector of pattern events
+        std::vector<StepEvent*> m_vEvents; // Vector of pattern events
         uint32_t m_nBeats = 4; // Quantity of beats in pattern
         uint32_t m_nStepsPerBeat = 6; // Steps per beat
         uint8_t m_nScale = 0; // Index of scale

--- a/zynlibs/zynseq/sequence.cpp
+++ b/zynlibs/zynseq/sequence.cpp
@@ -44,7 +44,7 @@ bool Sequence::removeTrack(size_t track)
     return true;
 }
 
-size_t Sequence::getTracks()
+uint32_t Sequence::getTracks()
 {
     return m_vTracks.size();
 }

--- a/zynlibs/zynseq/sequence.h
+++ b/zynlibs/zynseq/sequence.h
@@ -61,9 +61,9 @@ class Sequence
         bool removeTrack(size_t track);
 
         /** @brief  Get quantity of tracks in sequence
-        *   @retval size_t  Quantity of tracks
+        *   @retval uint32_t Quantity of tracks
         */
-        size_t getTracks();
+        uint32_t getTracks();
 
         /** @brief  Clear all tracks from sequence
         */

--- a/zynlibs/zynseq/zynseq.cpp
+++ b/zynlibs/zynseq/zynseq.cpp
@@ -37,7 +37,7 @@
 
 #include "metronome.h" // metronome wav data
 
-#define FILE_VERSION 7
+#define FILE_VERSION 8
 
 #define DPRINTF(fmt, args...) if(g_bDebug) fprintf(stderr, fmt, ## args)
 
@@ -803,11 +803,19 @@ bool load(const char* filename)
                 uint8_t nValue2start = fileRead8(pFile);
                 uint8_t nValue1end = fileRead8(pFile);
                 uint8_t nValue2end = fileRead8(pFile);
-                fileRead8(pFile); // Padding
                 StepEvent* pEvent = pPattern->addEvent(nStep, nCommand, nValue1start, nValue2start, fDuration);
                 pEvent->setValue1end(nValue1end);
                 pEvent->setValue2end(nValue2end);
                 nBlockSize -= 14;
+                if(nVersion > 7)
+                {
+                    uint8_t nStutterCount = fileRead8(pFile);
+                    uint8_t nStutterDur = fileRead8(pFile);
+                    pEvent->setStutterCount(nStutterCount);
+                    pEvent->setStutterDur(nStutterDur);
+                    nBlockSize -= 2;
+                }
+                fileRead8(pFile); // Padding
                 //printf(" Step:%u Duration:%u Command:%02X, Value1:%u..%u, Value2:%u..%u\n", nTime, nDuration, nCommand, nValue1start, nValue2end, nValue2start, nValue2end);
             }
         }
@@ -957,6 +965,8 @@ void save(const char* filename)
                 nPos += fileWrite8(pEvent->getValue2start(), pFile);
                 nPos += fileWrite8(pEvent->getValue1end(), pFile);
                 nPos += fileWrite8(pEvent->getValue2end(), pFile);
+                nPos += fileWrite8(pEvent->getStutterCount(), pFile);
+                nPos += fileWrite8(pEvent->getStutterDur(), pFile);
                 nPos += fileWrite8('\0', pFile); // Pad to even block (could do at end but simplest here)
             }
             nBlockSize = nPos - nStartOfBlock;
@@ -1349,6 +1359,38 @@ void setNoteVelocity(uint32_t step, uint8_t note, uint8_t velocity)
     g_bDirty = true;
 }
 
+uint8_t getStutterCount(uint32_t step, uint8_t note)
+{
+    if(!g_seqMan.getPattern(g_nPattern))
+        return 0;
+    return g_seqMan.getPattern(g_nPattern)->getStutterCount(step, note);
+}
+
+void setStutterCount(uint32_t step, uint8_t note, uint8_t count)
+{
+    if(!g_seqMan.getPattern(g_nPattern))
+        return;
+    setPatternModified(g_seqMan.getPattern(g_nPattern), true);
+    g_seqMan.getPattern(g_nPattern)->setStutterCount(step, note, count);
+    g_bDirty = true;
+}
+
+uint8_t getStutterDur(uint32_t step, uint8_t note)
+{
+    if(g_seqMan.getPattern(g_nPattern))
+        return g_seqMan.getPattern(g_nPattern)->getStutterDur(step, note);
+    return 0;
+}
+
+void setStutterDur(uint32_t step, uint8_t note, uint8_t dur)
+{
+    if(!g_seqMan.getPattern(g_nPattern))
+        return;
+    setPatternModified(g_seqMan.getPattern(g_nPattern), true);
+    g_seqMan.getPattern(g_nPattern)->setStutterDur(step, note, dur);
+    g_bDirty = true;
+}
+
 float getNoteDuration(uint32_t step, uint8_t note)
 {
     if(g_seqMan.getPattern(g_nPattern))
@@ -1694,7 +1736,7 @@ void setSequencesInBank(uint8_t bank, uint8_t sequences)
     g_pSequence = g_seqMan.getSequence(0, 0);
 }
 
-size_t getSequencesInBank(uint32_t bank)
+uint32_t getSequencesInBank(uint32_t bank)
 {
     return g_seqMan.getSequencesInBank(bank);
 }
@@ -1834,7 +1876,7 @@ void updateSequenceInfo()
 
 // ** Track management **
 
-size_t getPatternsInTrack(uint8_t bank, uint8_t sequence, uint32_t track)
+uint32_t getPatternsInTrack(uint8_t bank, uint8_t sequence, uint32_t track)
 {
     Track* pTrack = g_seqMan.getSequence(bank, sequence)->getTrack(track);
     if(!pTrack)

--- a/zynlibs/zynseq/zynseq.cpp
+++ b/zynlibs/zynseq/zynseq.cpp
@@ -1454,6 +1454,23 @@ void changeDurationAll(float value)
     g_bDirty = true;
 }
 
+void changeStutterCountAll(int value)
+{
+    if(!g_seqMan.getPattern(g_nPattern))
+        return;
+    setPatternModified(g_seqMan.getPattern(g_nPattern), true);
+    g_seqMan.getPattern(g_nPattern)->changeStutterCountAll(value);
+    g_bDirty = true;
+}
+
+void changeStutterDurAll(int value)
+{
+    if(!g_seqMan.getPattern(g_nPattern))
+        return;
+    setPatternModified(g_seqMan.getPattern(g_nPattern), true);
+    g_seqMan.getPattern(g_nPattern)->changeStutterDurAll(value);
+    g_bDirty = true;
+}
 
 void clear()
 {

--- a/zynlibs/zynseq/zynseq.h
+++ b/zynlibs/zynseq/zynseq.h
@@ -382,6 +382,16 @@ void changeVelocityAll(int value);
 */
 void changeDurationAll(float value);
 
+/** @brief  Change stutter count of all notes in patterm
+*   @param  value Offset to adjust +/-100 or whatever
+*/
+void changeStutterCountAll(int value);
+
+/** @brief  Change stutter duration of all notes in patterm
+*   @param  value Offset to adjust +/-100 or whatever
+*/
+void changeStutterDurAll(int value);
+
 /** @brief  Clears events from selected pattern
 *   @note   Does not change other parameters such as pattern length
 */

--- a/zynlibs/zynseq/zynseq.h
+++ b/zynlibs/zynseq/zynseq.h
@@ -314,6 +314,34 @@ uint8_t getNoteVelocity(uint32_t step, uint8_t note);
 */
 void setNoteVelocity(uint32_t step, uint8_t note, uint8_t velocity);
 
+/** @brief  Get stutter count of note in selected pattern
+*   @param  step Index of step at which note resides
+*   @param  note MIDI note number
+*   @retval uint8_t Stutter count
+*/
+uint8_t getStutterCount(uint32_t step, uint8_t note);
+
+/** @brief  Set stutter count of note in selected pattern
+*   @param  step Index of step at which note resides
+*   @param  note MIDI note number
+*   @param  count Stutter count
+*/
+void setStutterCount(uint32_t step, uint8_t note, uint8_t count);
+
+/** @brief  Get stutter duration of note in selected pattern
+*   @param  step Index of step at which note resides
+*   @param  note MIDI note number
+*   @retval uint8_t Stutter duration in clock cycles
+*/
+uint8_t getStutterDur(uint32_t step, uint8_t note);
+
+/** @brief  Set stutter duration of note in selected pattern
+*   @param  step Index of step at which note resides
+*   @param  note MIDI note number
+*   @param  dur Stutter duration in clock cycles
+*/
+void setStutterDur(uint32_t step, uint8_t note, uint8_t dur);
+
 /** @brief  Get duration of note in selected pattern
 *   @param  position Index of step at which note starts
 *   @note   note MIDI note number
@@ -544,8 +572,9 @@ void togglePlayState(uint8_t bank, uint8_t sequence);
 /** @brief  Get quantity of tracks in a sequence
 *   @param  bank Index of bank
 *   @param  sequence Index of sequence
+*   @retval uint32_t Quantity of tracks in sequence
 */
-size_t getTracksInSequence(uint8_t bank, uint8_t sequence);
+uint32_t getTracksInSequence(uint8_t bank, uint8_t sequence);
 
 /** @brief  Stops all sequences
 */


### PR DESCRIPTION
Fixes failure to set change parameters of existing notes, e.g. velocity. Fix some compile errors (evident in later versions of gcc).

The stutter effect allows each note of a pattern to trigger a configurable quantity of note on/off events at configurable interval before completing the note duration. The quantity is limited by duration of the note. (There may need to be some changes in UI to present the limitations but that gets complex.) The duration of stutter is measured in clock cycles which is currently 24 clocks per quarter note. (This resolution may be increased in future.) Menu options have been added to allow setting the stutter parameters for the selected note in a pattern and the file format has updated to v8 to store the extra data. File is backward compatible. Older versions will not load newer versions.