### PR TITLE
Feature/slave to midi clock

### DIFF
--- a/zyngui/zynthian_gui_admin.py
+++ b/zyngui/zynthian_gui_admin.py
@@ -86,6 +86,11 @@ class zynthian_gui_admin(zynthian_gui_selector):
 		else:
 			self.list_data.append((self.toggle_bank_change,0,"[  ] MIDI Bank Change"))
 
+		if zynthian_gui_config.transport_clock_source:
+			self.list_data.append((self.toggle_clock_source,0,"Clock Source: INTERNAL"))
+		else:
+			self.list_data.append((self.toggle_clock_source,0,"Clock Source: MIDI"))
+
 		if zynthian_gui_config.preset_preload_noteon:
 			self.list_data.append((self.toggle_preset_preload_noteon,0,"[x] Preset Preload"))
 		else:
@@ -425,6 +430,20 @@ class zynthian_gui_admin(zynthian_gui_selector):
 		# Save config
 		zynconf.update_midi_profile({ 
 			"ZYNTHIAN_MIDI_BANK_CHANGE": str(int(zynthian_gui_config.midi_bank_change))
+		})
+
+		self.fill_list()
+
+
+	def toggle_clock_source(self):
+		if zynthian_gui_config.transport_clock_source:
+			zynthian_gui_config.transport_clock_source = 0
+		else:
+			zynthian_gui_config.transport_clock_source = 1
+
+		# Save config
+		zynconf.update_midi_profile({
+			"ZYNTHIAN_TRANSPORT_CLOCK_SOURCE": str(int(zynthian_gui_config.transport_clock_source))
 		})
 
 		self.fill_list()

--- a/zyngui/zynthian_gui_admin.py
+++ b/zyngui/zynthian_gui_admin.py
@@ -87,9 +87,9 @@ class zynthian_gui_admin(zynthian_gui_selector):
 			self.list_data.append((self.toggle_bank_change,0,"[  ] MIDI Bank Change"))
 
 		if zynthian_gui_config.transport_clock_source:
-			self.list_data.append((self.toggle_clock_source,0,"Clock Source: INTERNAL"))
-		else:
 			self.list_data.append((self.toggle_clock_source,0,"Clock Source: MIDI"))
+		else:
+			self.list_data.append((self.toggle_clock_source,0,"Clock Source: INTERNAL"))
 
 		if zynthian_gui_config.preset_preload_noteon:
 			self.list_data.append((self.toggle_preset_preload_noteon,0,"[x] Preset Preload"))
@@ -440,6 +440,7 @@ class zynthian_gui_admin(zynthian_gui_selector):
 			zynthian_gui_config.transport_clock_source = 0
 		else:
 			zynthian_gui_config.transport_clock_source = 1
+		self.zyngui.zynseq.libseq.setClockSource(zynthian_gui_config.transport_clock_source)
 
 		# Save config
 		zynconf.update_midi_profile({

--- a/zyngui/zynthian_gui_arranger.py
+++ b/zyngui/zynthian_gui_arranger.py
@@ -184,7 +184,8 @@ class zynthian_gui_arranger(zynthian_gui_base.zynthian_gui_base):
 		self.disable_param_editor()
 		options = OrderedDict()
 		options['Bank ({})'.format(self.zyngui.zynseq.bank)] = 'Bank'
-		options['Tempo ({:0.1f})'.format(self.zyngui.zynseq.libseq.getTempo())] = 'Tempo'
+		if zynthian_gui_config.transport_clock_source == 0:
+			options['Tempo ({:0.1f})'.format(self.zyngui.zynseq.libseq.getTempo())] = 'Tempo'
 		options['Beats per bar ({})'.format(self.zyngui.zynseq.libseq.getBeatsPerBar())] = 'Beats per bar'
 		if self.zyngui.zynseq.libseq.isMetronomeEnabled():
 			options['[X] Metronome'] = 'Metronome'
@@ -1187,7 +1188,8 @@ class zynthian_gui_arranger(zynthian_gui_base.zynthian_gui_base):
 			self.select_cell(self.selected_cell[0] + dval, self.selected_cell[1])
 		elif encoder == zynthian_gui_config.ENC_LAYER:
 			self.set_pattern(self.pattern + dval)
-		elif encoder == zynthian_gui_config.ENC_SNAPSHOT:
+		elif encoder == zynthian_gui_config.ENC_SNAPSHOT and zynthian_gui_config.transport_clock_source == 0:
+			self.zyngui.zynseq.update_tempo()
 			self.zyngui.zynseq.nudge_tempo(dval)
 			self.set_title("Tempo: {:.1f}".format(self.zyngui.zynseq.get_tempo()), None, None, 2)
 

--- a/zyngui/zynthian_gui_config.py
+++ b/zyngui/zynthian_gui_config.py
@@ -268,6 +268,7 @@ def set_midi_config():
 	global master_midi_bank_change_up, master_midi_bank_change_down
 	global master_midi_bank_change_down_ccnum, master_midi_bank_base
 	global disabled_midi_in_ports, enabled_midi_out_ports, enabled_midi_fb_ports
+	global transport_clock_source
 
 	# MIDI options
 	midi_fine_tuning=float(os.environ.get('ZYNTHIAN_MIDI_FINE_TUNING',440.0))
@@ -282,6 +283,7 @@ def set_midi_config():
 	midi_rtpmidi_enabled=int(os.environ.get('ZYNTHIAN_MIDI_RTPMIDI_ENABLED',0))
 	midi_touchosc_enabled=int(os.environ.get('ZYNTHIAN_MIDI_TOUCHOSC_ENABLED',0))
 	midi_aubionotes_enabled=int(os.environ.get('ZYNTHIAN_MIDI_AUBIONOTES_ENABLED',0))
+	transport_clock_source = int(os.environ.get('ZYNTHIAN_TRANSPORT_CLOCK_SOURCE', 0))
 
 	# Filter Rules
 	midi_filter_rules=os.environ.get('ZYNTHIAN_MIDI_FILTER_RULES',"")

--- a/zyngui/zynthian_gui_config.py
+++ b/zyngui/zynthian_gui_config.py
@@ -283,7 +283,7 @@ def set_midi_config():
 	midi_rtpmidi_enabled=int(os.environ.get('ZYNTHIAN_MIDI_RTPMIDI_ENABLED',0))
 	midi_touchosc_enabled=int(os.environ.get('ZYNTHIAN_MIDI_TOUCHOSC_ENABLED',0))
 	midi_aubionotes_enabled=int(os.environ.get('ZYNTHIAN_MIDI_AUBIONOTES_ENABLED',0))
-	transport_clock_source = int(os.environ.get('ZYNTHIAN_TRANSPORT_CLOCK_SOURCE', 0))
+	transport_clock_source=int(os.environ.get('ZYNTHIAN_TRANSPORT_CLOCK_SOURCE',0))
 
 	# Filter Rules
 	midi_filter_rules=os.environ.get('ZYNTHIAN_MIDI_FILTER_RULES',"")

--- a/zyngui/zynthian_gui_midi_recorder.py
+++ b/zyngui/zynthian_gui_midi_recorder.py
@@ -99,7 +99,7 @@ class zynthian_gui_midi_recorder(zynthian_gui_selector):
 
 	def build_view(self):
 		super().build_view()
-		if libsmf.getPlayState():
+		if zynthian_gui_config.transport_clock_source == 0 and libsmf.getPlayState():
 			self.show_playing_bpm()
 
 
@@ -323,7 +323,8 @@ class zynthian_gui_midi_recorder(zynthian_gui_selector):
 			self.zyngui.zynseq.transport_start("zynsmf")
 #			self.zyngui.zynseq.libseq.transportLocate(0)
 			self.current_playback_fpath=fpath
-			self.show_playing_bpm()
+			if zynthian_gui_config.transport_clock_source == 0:
+				self.show_playing_bpm()
 			self.smf_timer = Timer(interval = 1, function=self.check_playback)
 			self.smf_timer.start()
 		except Exception as e:
@@ -390,6 +391,7 @@ class zynthian_gui_midi_recorder(zynthian_gui_selector):
 				column = zynthian_gui_config.layout['ctrl_pos'][bmp_ctrl_index][1],
 				sticky = 'news'
 			)
+		self.zyngui.zynseq.update_tempo()
 
 
 	def hide_playing_bpm(self):

--- a/zyngui/zynthian_gui_patterneditor.py
+++ b/zyngui/zynthian_gui_patterneditor.py
@@ -224,7 +224,8 @@ class zynthian_gui_patterneditor(zynthian_gui_base.zynthian_gui_base):
 	def show_menu(self):
 		self.disable_param_editor()
 		options = OrderedDict()
-		options['Tempo ({:0.1f})'.format(self.zyngui.zynseq.libseq.getTempo())] = 'Tempo'
+		if zynthian_gui_config.transport_clock_source == 0:
+			options['Tempo ({:0.1f})'.format(self.zyngui.zynseq.libseq.getTempo())] = 'Tempo'
 		options['Beats per bar ({})'.format(self.zyngui.zynseq.libseq.getBeatsPerBar())] = 'Beats per bar'
 		if self.zyngui.zynseq.libseq.isMetronomeEnabled():
 			options['[X] Metronome'] = 'Metronome'
@@ -1134,7 +1135,8 @@ class zynthian_gui_patterneditor(zynthian_gui_base.zynthian_gui_base):
 					self.zyngui.zynseq.libseq.changeDurationAll(-0.1)
 				self.set_title("ALL DURATION", None, None, 2)
 				self.redraw_pending = 3
-			else:
+			elif zynthian_gui_config.transport_clock_source == 0:
+				self.zyngui.zynseq.update_tempo()
 				self.zyngui.zynseq.nudge_tempo(dval)
 				self.set_title("Tempo: {:.1f}".format(self.zyngui.zynseq.get_tempo()), None, None, 2)
 

--- a/zyngui/zynthian_gui_patterneditor.py
+++ b/zyngui/zynthian_gui_patterneditor.py
@@ -1010,11 +1010,9 @@ class zynthian_gui_patterneditor(zynthian_gui_base.zynthian_gui_base):
 	#   index: Pattern index
 	def load_pattern(self, index):
 		steps = self.zyngui.zynseq.libseq.getSteps()
-		self.zyngui.zynseq.libseq.clearSequence(self.bank, self.sequence)
 		self.zyngui.zynseq.libseq.setChannel(self.bank, self.sequence, 0, self.channel)
 		self.pattern = index
 		self.zyngui.zynseq.libseq.selectPattern(index)
-		self.zyngui.zynseq.libseq.addPattern(self.bank, self.sequence, 0, 0, index)
 		if self.selected_cell[0] >= self.zyngui.zynseq.libseq.getSteps():
 			self.selected_cell[0] = int(self.zyngui.zynseq.libseq.getSteps()) - 1
 		self.keymap_offset = self.zyngui.zynseq.libseq.getRefNote()

--- a/zyngui/zynthian_gui_zynpad.py
+++ b/zyngui/zynthian_gui_zynpad.py
@@ -330,7 +330,8 @@ class zynthian_gui_zynpad(zynthian_gui_base.zynthian_gui_base):
 		options = OrderedDict()
 		options['Arranger'] = 'Arranger'
 		options['Bank ({})'.format(self.zyngui.zynseq.bank)] = 'Bank'
-		options['Tempo ({:0.1f})'.format(self.zyngui.zynseq.libseq.getTempo())] = 'Tempo'
+		if zynthian_gui_config.transport_clock_source == 0:
+			options['Tempo ({:0.1f})'.format(self.zyngui.zynseq.libseq.getTempo())] = 'Tempo'
 		options['Beats per bar ({})'.format(self.zyngui.zynseq.libseq.getBeatsPerBar())] = 'Beats per bar'
 		if self.zyngui.zynseq.libseq.isMetronomeEnabled():
 			options['[X] Metronome'] = 'Metronome'
@@ -509,7 +510,8 @@ class zynthian_gui_zynpad(zynthian_gui_base.zynthian_gui_base):
 				return
 			self.selected_pad = pad
 			self.update_selection_cursor()
-		elif encoder == zynthian_gui_config.ENC_SNAPSHOT:
+		elif encoder == zynthian_gui_config.ENC_SNAPSHOT and zynthian_gui_config.transport_clock_source == 0:
+			self.zyngui.zynseq.update_tempo()
 			self.zyngui.zynseq.nudge_tempo(dval)
 			self.set_title("Tempo: {:.1f}".format(self.zyngui.zynseq.get_tempo()), None, None, 2)
 		elif encoder == zynthian_gui_config.ENC_LAYER:

--- a/zynlibs/zynseq/pattern.cpp
+++ b/zynlibs/zynseq/pattern.cpp
@@ -180,20 +180,20 @@ uint32_t Pattern::getSteps()
 
 uint32_t Pattern::getLength()
 {
-    return m_nBeats * 24;
+    return m_nBeats * PPQN;
 }
 
 uint32_t Pattern::getClocksPerStep()
 {
-    if(m_nStepsPerBeat > 24 || m_nStepsPerBeat == 0)
+    if(m_nStepsPerBeat > PPQN || m_nStepsPerBeat == 0)
         return 1;
-    return 24 / m_nStepsPerBeat;
+    return PPQN / m_nStepsPerBeat;
 }
 
 bool Pattern::setStepsPerBeat(uint32_t value)
 {
     float fScale = 1.0;
-    if(m_nStepsPerBeat == 0 || m_nStepsPerBeat > 24)
+    if(m_nStepsPerBeat == 0 || m_nStepsPerBeat > PPQN)
         m_nStepsPerBeat = 4;
     else
         float fScale = float(value) / m_nStepsPerBeat;

--- a/zynlibs/zynseq/pattern.h
+++ b/zynlibs/zynseq/pattern.h
@@ -4,11 +4,14 @@
 #include <vector>
 #include <memory>
 
+const static uint32_t PPQN = 24;
+
 /** StepEvent class provides an individual step event .
 *   The event may be part of a song, pattern or sequence. Events do not have MIDI channel which is applied by the function to play the event, e.g. pattern player assigned to specific channel. Events have the concept of position which is an offset from some epoch measured in steps. The epoch depends on the function using the event, e.g. pattern player may use start of pattern as epoch (position = 0). There is a starting and end value to allow interpolation of MIDI events between the start and end positions.
 */
 class StepEvent
 {
+
     public:
         /** Default constructor of StepEvent object
         */

--- a/zynlibs/zynseq/sequence.h
+++ b/zynlibs/zynseq/sequence.h
@@ -113,7 +113,7 @@ class Sequence
         *   @param  bSync True to indicate sync pulse, e.g. to sync tracks
         *   @param  dSamplesPerClock Samples per clock
         *   @retval uint8_t Bitwise flag of what clock triggers [1=track step | 2=change of state]
-        *     @note    Sequences are clocked syncronously but not locked to absolute time so depend on start time for absolute timing
+        *   @note   Sequences are clocked syncronously but not locked to absolute time so depend on start time for absolute timing
         *   @note   Will clock each track
         */
         uint8_t clock(uint32_t nTime, bool bSync, double dSamplesPerClock);
@@ -184,4 +184,3 @@ class Sequence
         bool m_bEmpty = true; // True if all patterns are emtpy (no events)
         std::string m_sName; // Sequence name
 };
-

--- a/zynlibs/zynseq/sequencemanager.h
+++ b/zynlibs/zynseq/sequencemanager.h
@@ -208,7 +208,7 @@ class SequenceManager
         */
         void removeSequence(uint8_t bank, uint8_t sequence);
 
-        /**    @brief    Remove all sequences from bank
+        /** @brief    Remove all sequences from bank
         *   @param  bank Index of bank
         */
         void clearBank(uint32_t bank);
@@ -216,7 +216,7 @@ class SequenceManager
         /** @brief  Get quantity of banks
         *   @retval uint32_t Quantity of populated banks
         */
-       uint32_t getBanks();
+        uint32_t getBanks();
 
     private:
 

--- a/zynlibs/zynseq/zynseq.cpp
+++ b/zynlibs/zynseq/zynseq.cpp
@@ -364,7 +364,7 @@ int onJackProcess(jack_nframes_t nFrames, void *pArgs)
                 if(g_nClockSource == TRANSPORT_CLOCK_MIDI)
                 {
                     g_dFramesToNextClock = midiEvent.time;
-                    if(++nClocksSinceLastBeat > 24)
+                    if(++nClocksSinceLastBeat > 23)
                     {
                         // Update tempo on each beat
                         if(nLastBeatFrame)

--- a/zynlibs/zynseq/zynseq.cpp
+++ b/zynlibs/zynseq/zynseq.cpp
@@ -419,7 +419,7 @@ int onJackProcess(jack_nframes_t nFrames, void *pArgs)
         if(g_bInputEnabled && g_pSequence && pPattern && g_nInputChannel == (midiEvent.buffer[0] & 0x0F))
         {
             uint32_t nStep = getPatternPlayhead();
-            uint8_t nPlayState = transportGetPlayStatus();
+            uint8_t nPlayState = getPlayState(0, 0);
             bool bAdvance = false;
             if(((midiEvent.buffer[0] & 0xF0) == 0xB0) && midiEvent.buffer[1] == 64)
             {

--- a/zynlibs/zynseq/zynseq.cpp
+++ b/zynlibs/zynseq/zynseq.cpp
@@ -88,7 +88,7 @@ uint32_t g_nTick = 0; // Current tick within bar
 double g_dBarStartTick = 0; // Quantity of ticks from start of song to start of current bar
 jack_nframes_t g_nTransportStartFrame = 0; // Quantity of frames from JACK epoch to transport start
 double g_dFramesToNextClock = 99999.0; // Frames until next clock pulse
-double g_dFramesPerClock = 60 * g_nSampleRate / (g_dTempo *  g_dTicksPerBeat) * g_dTicksPerClock; //!@todo Change to integer will have 0.1% jitter at 1920 PPQN and much better jitter (0.01%) at current 24PPQN
+double g_dFramesPerClock = getFramesPerClock(g_dTempo); //!@todo Change to integer will have 0.1% jitter at 1920 PPQN and much better jitter (0.01%) at current 24PPQN
 uint8_t g_nClock = 0; // Quantity of MIDI clocks since start of beat
 uint8_t g_nClockSource = TRANSPORT_CLOCK_INTERNAL; // Source of clock that progresses playback
 jack_nframes_t g_nFramesSinceLastBeat = 0; // Quantity of frames since last beat
@@ -2013,7 +2013,7 @@ void setTempo(double tempo)
     if(tempo > 0.0 && tempo < 500.0)
     {
         g_dTempo = tempo;
-        g_dFramesPerClock = getFramesPerClock(tempo);
+        g_dFramesPerClock = getFramesPerClock(g_dTempo);
     }
 }
 

--- a/zynlibs/zynseq/zynseq.cpp
+++ b/zynlibs/zynseq/zynseq.cpp
@@ -2064,4 +2064,5 @@ uint8_t getClockSource()
 void setClockSource(uint8_t source)
 {
     g_nClockSource = source;
+    g_dFramesToNextClock = 0.0;
 }

--- a/zynlibs/zynseq/zynseq.cpp
+++ b/zynlibs/zynseq/zynseq.cpp
@@ -2013,7 +2013,10 @@ void setTempo(double tempo)
     if(tempo > 0.0 && tempo < 500.0)
     {
         g_dTempo = tempo;
-        g_dFramesPerClock = getFramesPerClock(g_dTempo);
+        if(transportGetPlayStatus() != JackTransportRolling)
+            transportLocate(0); // Cludge to update transport tempo when transport not running
+        else
+            g_dFramesPerClock = getFramesPerClock(g_dTempo);
     }
 }
 

--- a/zynlibs/zynseq/zynseq.h
+++ b/zynlibs/zynseq/zynseq.h
@@ -57,6 +57,11 @@ extern "C"
 {
 #endif
 
+enum TRANSPORT_CLOCK
+{
+    TRANSPORT_CLOCK_INTERNAL = 0,
+    TRANSPORT_CLOCK_MIDI = 1
+};
 
 // ** Library management functions **
 
@@ -545,7 +550,7 @@ void togglePlayState(uint8_t bank, uint8_t sequence);
 *   @param  bank Index of bank
 *   @param  sequence Index of sequence
 */
-size_t getTracksInSequence(uint8_t bank, uint8_t sequence);
+uint32_t getTracksInSequence(uint8_t bank, uint8_t sequence);
 
 /** @brief  Stops all sequences
 */
@@ -842,7 +847,16 @@ void setMetronomeVolume(float level);
 */
 float getMetronomeVolume();
 
+/** @brief Get clock source
+*   @retval uint8_t Clock source [0:Internal 1:MIDI]
+*/
+uint8_t getClockSource();
+
+/** @brief Set clock source
+*   @source uint8_t Clock source [0:Internal 1:MIDI]
+*/
+void setClockSource(uint8_t source);
+
 #ifdef __cplusplus
 }
 #endif
-

--- a/zynlibs/zynseq/zynseq.h
+++ b/zynlibs/zynseq/zynseq.h
@@ -857,6 +857,11 @@ uint8_t getClockSource();
 */
 void setClockSource(uint8_t source);
 
+/** @brief  Get quantity of frames in each clock cycle
+*   @retval double Quantity of frames
+*/
+double getFramesPerClock(double dTempo);
+
 #ifdef __cplusplus
 }
 #endif

--- a/zynlibs/zynseq/zynseq.h
+++ b/zynlibs/zynseq/zynseq.h
@@ -853,7 +853,7 @@ float getMetronomeVolume();
 uint8_t getClockSource();
 
 /** @brief Set clock source
-*   @source uint8_t Clock source [0:Internal 1:MIDI]
+*   @param source uint8_t Clock source [0:Internal 1:MIDI]
 */
 void setClockSource(uint8_t source);
 

--- a/zynlibs/zynseq/zynseq.py
+++ b/zynlibs/zynseq/zynseq.py
@@ -279,9 +279,9 @@ class zynseq(zynthian_engine):
 
 
 	def update_tempo(self):
-		self.set_tempo(self.get_tempo)
+		self.set_tempo(self.libseq.getTempo())
 
-	
+
 	def nudge_tempo(self, offset):
 		self.zctrl_tempo.nudge(offset)
 

--- a/zynlibs/zynseq/zynseq.py
+++ b/zynlibs/zynseq/zynseq.py
@@ -114,14 +114,14 @@ class zynseq(zynthian_engine):
 		self.libseq = None
 
 
-	#	Function to add an view to send events to
+	#	Function to add a view to send events to
 	#	cb: Callback function
 	def add_event_cb(self, cb):
 		if cb not in self.event_cb_list:
 			self.event_cb_list.append(cb)
 
 
-	#	Function to remove an view to send events to
+	#	Function to remove a view to send events to
 	#	cb: Callback function
 	def remove_event_cb(self, cb):
 		if cb in self.event_cb_list:
@@ -276,6 +276,10 @@ class zynseq(zynthian_engine):
 	
 	def get_tempo(self):
 		return self.libseq.getTempo()
+
+
+	def update_tempo(self):
+		self.set_tempo(self.get_tempo)
 
 	
 	def nudge_tempo(self, offset):

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -1056,7 +1056,25 @@ class zynthian_gui:
 			self.zynseq.set_tempo(params[0])
 		except (AttributeError, TypeError) as err:
 			pass
-	
+
+	def cuia_tempo_up(self, params):
+		if params:
+			try:
+				self.zynseq.set_tempo(self.zynseq.get_tempo() + params[0])
+			except (AttributeError, TypeError) as err:
+				pass
+		else:
+			self.zynseq.set_tempo(self.zynseq.get_tempo() + 1)
+
+	def cuia_tempo_down(self, params):
+		if params:
+			try:
+				self.zynseq.set_tempo(self.zynseq.get_tempo() - params[0])
+			except (AttributeError, TypeError) as err:
+				pass
+		else:
+			self.zynseq.set_tempo(self.zynseq.get_tempo() - 1)
+
 	def cuia_tap_tempo(self, params):
 		now = monotonic()
 		tap_dur = now - self.last_tap

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -31,9 +31,8 @@ import ctypes
 import signal
 import logging
 import importlib
-from time import sleep
 from pathlib import Path
-from time import monotonic
+from time import sleep, monotonic
 from glob import glob
 from datetime import datetime
 from threading  import Thread, Lock
@@ -483,6 +482,8 @@ class zynthian_gui:
 			# Try to load "default" snapshot ...
 			if not snapshot_loaded:
 				snapshot_loaded = self.screens['snapshot'].load_default_snapshot()
+
+		self.last_tap = 0
 
 		if snapshot_loaded:
 			init_screen = "audio_mixer"
@@ -1055,6 +1056,13 @@ class zynthian_gui:
 			self.zynseq.set_tempo(params[0])
 		except (AttributeError, TypeError) as err:
 			pass
+	
+	def cuia_tap_tempo(self, params):
+		now = monotonic()
+		tap_dur = now - self.last_tap
+		if tap_dur > 0.14285 and tap_dur <= 3:
+			self.zynseq.set_tempo(60 / tap_dur)
+		self.last_tap = now
 
 	# Basic UI-Control CUIAs
 	# 4 x Arrows

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -521,7 +521,7 @@ class zynthian_gui:
 			if self.midi_filter_script:
 				self.midi_filter_script.clean()
 			self.midi_filter_script = zynthian_midi_filter.MidiFilterScript(zynthian_gui_config.midi_filter_rules)
-			self.zynseq.setClockSource(zynthian_gui_config.transport_clock_source)
+			self.zynseq.libseq.setClockSource(zynthian_gui_config.transport_clock_source)
 
 		except Exception as e:
 			logging.error("ERROR initializing MIDI : {}".format(e))

--- a/zynthian_gui.py
+++ b/zynthian_gui.py
@@ -521,6 +521,7 @@ class zynthian_gui:
 			if self.midi_filter_script:
 				self.midi_filter_script.clean()
 			self.midi_filter_script = zynthian_midi_filter.MidiFilterScript(zynthian_gui_config.midi_filter_rules)
+			self.zynseq.setClockSource(zynthian_gui_config.transport_clock_source)
 
 		except Exception as e:
 			logging.error("ERROR initializing MIDI : {}".format(e))


### PR DESCRIPTION
Adds slave to MIDI.
Can now change tempo for plugins (like arpeggiator) when sequencer / SMF player not rolling.
Adds various CUIA for tempo.
Fixes live playing to record sequences.