### PR TITLE
ZynSeq fixes

### DIFF
--- a/zyngui/zynthian_gui_arranger.py
+++ b/zyngui/zynthian_gui_arranger.py
@@ -751,7 +751,7 @@ class zynthian_gui_arranger(zynthian_gui_base.zynthian_gui_base):
 		sequence = self.sequence_tracks[row + self.row_offset][0]
 		track = self.sequence_tracks[row + self.row_offset][1]
 		group = self.zyngui.zynseq.libseq.getGroup(self.zyngui.zynseq.bank, sequence)
-		fill = zynthian_gui_config.PAD_COLOUR_STOPPED[group % 16]
+		fill = zynthian_gui_config.PAD_COLOUR_GROUP_LIGHT[group % 16]
 		font = tkFont.Font(family=zynthian_gui_config.font_topbar[0], size=self.fontsize)
 		channel = self.zyngui.zynseq.libseq.getChannel(self.zyngui.zynseq.bank, sequence, track)
 		if channel < 16 and self.layers[channel]:

--- a/zynlibs/zynseq/sequencemanager.cpp
+++ b/zynlibs/zynseq/sequencemanager.cpp
@@ -137,8 +137,10 @@ void SequenceManager::copyPattern(uint32_t source, uint32_t destination)
 Sequence* SequenceManager::getSequence(uint8_t bank, uint8_t sequence)
 {
     // Add missing sequences
-    while(m_mBanks[bank].size() <= sequence)
+    while(m_mBanks[bank].size() <= sequence) {
         m_mBanks[bank].push_back(new Sequence());
+        addPattern(bank, m_mBanks[bank].size() - 1, 0, 0, createPattern(), false);
+    }
     return m_mBanks[bank][sequence];
 }
 
@@ -367,20 +369,14 @@ void SequenceManager::setSequencesInBank(uint8_t bank, uint8_t sequences)
     size_t nSize = m_mBanks[bank].size();
     while(nSize > sequences)
     {
-        setSequencePlayState(bank, --nSize, STOPPED);
-        delete getSequence(bank, nSize);
+        setSequencePlayState(bank, nSize - 1, STOPPED);
+        delete m_mBanks[bank].back();
         m_mBanks[bank].pop_back();
+        nSize = m_mBanks[bank].size();
     }
     cleanPatterns();
     // Add required sequences
-    for(size_t nSequence = nSize; nSequence < sequences; ++nSequence)
-    {
-        Sequence* pSequence = new Sequence();
-        m_mBanks[bank].push_back(pSequence);
-        // Add a new pattern at start of eacn new track
-        uint32_t nPattern = createPattern();
-        addPattern(bank, nSequence, 0, 0, nPattern, false);
-    }
+    getSequence(bank, sequences - 1);
 }
 
 uint32_t SequenceManager::getSequencesInBank(uint32_t bank)
@@ -412,17 +408,8 @@ bool SequenceManager::moveSequence(uint8_t bank, uint8_t sequence, uint8_t posit
 
 void SequenceManager::insertSequence(uint8_t bank, uint8_t sequence)
 {
-    if(sequence >= m_mBanks[bank].size())
-    {
-        setSequencesInBank(bank, sequence + 1);
-        return;
-    }
-    Sequence* pSequence = new Sequence();
-    m_mBanks[bank].insert(m_mBanks[bank].begin() + sequence, pSequence);
-    // Add a new pattern at start of eacn new track
-    cleanPatterns();
-    uint32_t nPattern = createPattern();
-    addPattern(bank, sequence, 0, 0, nPattern, false);
+    m_mBanks[bank].insert(m_mBanks[bank].begin() + sequence, new Sequence());
+    addPattern(bank, sequence, 0, 0, createPattern(), false);
 }
 
 void SequenceManager::removeSequence(uint8_t bank, uint8_t sequence)

--- a/zynlibs/zynseq/zynseq.py
+++ b/zynlibs/zynseq/zynseq.py
@@ -165,7 +165,6 @@ class zynseq(zynthian_engine):
 					self.set_sequence_name(bank, seq, "{}".format(self.libseq.getPatternAt(bank, seq, 0, 0)))
 					self.libseq.setGroup(bank, seq, channel)
 					self.libseq.setChannel(bank, seq, 0, channel)
-			self.send_event(SEQ_EVENT_BANK)
 
 
 	#	Function to add / remove sequences to change bank size
@@ -217,8 +216,6 @@ class zynseq(zynthian_engine):
 	#	filename: Full path and filename
 	def load(self, filename):
 		self.libseq.load(bytes(filename, "utf-8"))
-		if self.libseq.getSequencesInBank(1) == 0:
-			self.build_default_bank(1)
 		self.send_event(SEQ_EVENT_LOAD)
 
 


### PR DESCRIPTION
Fix missing colours in arranger.
Use queue for zynpad callbacks to avoid re-entrant crashes.
Fix libseq bank size issue.

These are important fixes to the sequencer.