### PR TITLE
Fix logic for enable_touch_controller_switches

### DIFF
--- a/zyngui/zynthian_gui_base.py
+++ b/zyngui/zynthian_gui_base.py
@@ -325,14 +325,12 @@ class zynthian_gui_base(tkinter.Frame):
 
 	# Default topbar short touch action
 	def topbar_touch_action(self):
-		if zynthian_gui_config.enable_touch_controller_switches:
-			self.zyngui.zynswitch_defered('S', 1)
+		self.zyngui.zynswitch_defered('S', 1)
 
 
 	# Default topbar bold touch action
 	def topbar_bold_touch_action(self):
-		if zynthian_gui_config.enable_touch_controller_switches:
-			self.zyngui.zynswitch_defered('B', 0)
+		self.zyngui.zynswitch_defered('B', 0)
 
 
 	# Default topbar bold press callback

--- a/zyngui/zynthian_gui_config.py
+++ b/zyngui/zynthian_gui_config.py
@@ -479,7 +479,7 @@ enable_touch_widgets = int(os.environ.get('ZYNTHIAN_UI_TOUCH_WIDGETS', False))
 enable_onscreen_buttons = int(os.environ.get('ZYNTHIAN_UI_ONSCREEN_BUTTONS', False))
 force_enable_cursor = int(os.environ.get('ZYNTHIAN_UI_ENABLE_CURSOR', False))
 
-if wiring_layout.startswith("Z2") and not enable_onscreen_buttons:
+if enable_onscreen_buttons:
 	enable_touch_controller_switches = 0
 else:
 	enable_touch_controller_switches = 1


### PR DESCRIPTION
When there are visible screen buttons, the controller touch interface doesn't need to be overloaded with button press actions. Accidental button presses are common when making small touch value changes, so if there is buttons on the actual screen the controllers shouldn't handle touches as buttons.

This seems to be the intent of enable_touch_controller_switches but the logic is inverted and also includes a Z2 wiring layout which may no longer be relevant.

This change also enables touching the top bar for back button presses, regardless of the value of enable_touch_controller_switches. This is because there is often no on screen alternative to trigger back button presses.