### PR TITLE
Switch to using an arrow cursor instead of a cross

### DIFF
--- a/zyngui/zynthian_gui_config.py
+++ b/zyngui/zynthian_gui_config.py
@@ -627,7 +627,7 @@ if "zynthian_main.py" in sys.argv[0]:
 
 		# Disable cursor for real Zynthian Boxes
 		if force_enable_cursor or wiring_layout == "EMULATOR" or wiring_layout == "DUMMIES":
-			top.config(cursor="cross")
+			top.config(cursor="arrow")
 		else:
 			top.config(cursor="none")
 


### PR DESCRIPTION
The crosshair cursor is very hard to see on a typical zynthian screen, and is non standard from a usability point of view.

This change switches the cursor to an arrow instead of the crosshair.