### PR TITLE
Fix build with g++ 11.4.0

### DIFF
--- a/zynlibs/zynaudioplayer/player.cpp
+++ b/zynlibs/zynaudioplayer/player.cpp
@@ -334,9 +334,9 @@ void* file_thread_fn(void * param) {
                             nUnusedFrames = nFramesRead - srcData.input_frames_used;
                             nFramesRead = srcData.output_frames_gen;
                             if(rc) {
-                                DPRINTF("SRC failed with error %d, %u frames generated\n", nFramesRead, srcData.output_frames_gen);
+                                DPRINTF("SRC failed with error %d, %lu frames generated\n", nFramesRead, srcData.output_frames_gen);
                             } else {
-                                DPRINTF("SRC suceeded - %u frames generated, %u frames used, %u frames unused\n", srcData.output_frames_gen, srcData.input_frames_used, nUnusedFrames);
+                                DPRINTF("SRC suceeded - %lu frames generated, %lu frames used, %lu frames unused\n", srcData.output_frames_gen, srcData.input_frames_used, nUnusedFrames);
                             }
                             // Shift unused samples to start of buffer
                             memcpy(pBufferIn, pBufferIn + srcData.input_frames_used * sizeof(float) * pPlayer->sf_info.channels, nUnusedFrames * sizeof(float) * pPlayer->sf_info.channels);
@@ -1151,10 +1151,10 @@ void remove_player(AUDIO_PLAYER * pPlayer) {
         return;
     unload(pPlayer);
     if (jack_port_unregister(g_jack_client, pPlayer->jack_out_a)) {
-        fprintf(stderr, "libaudioplayer error: cannot unregister audio output port %02dA\n", pPlayer + 1);
+        fprintf(stderr, "libaudioplayer error: cannot unregister audio output port %02dA\n", pPlayer->index);
     }
     if (jack_port_unregister(g_jack_client, pPlayer->jack_out_b)) {
-        fprintf(stderr, "libaudioplayer error: cannot unregister audio output port %02dB\n", pPlayer + 1);
+        fprintf(stderr, "libaudioplayer error: cannot unregister audio output port %02dB\n", pPlayer->index);
     }
     auto it = find(g_vPlayers.begin(), g_vPlayers.end(), pPlayer);
     if (it != g_vPlayers.end())

--- a/zynlibs/zynaudioplayer/tinyosc.c
+++ b/zynlibs/zynaudioplayer/tinyosc.c
@@ -309,8 +309,8 @@ void tosc_printMessage(tosc_message *osc) {
       case 'f': printf(" %g", tosc_getNextFloat(osc)); break;
       case 'd': printf(" %g", tosc_getNextDouble(osc)); break;
       case 'i': printf(" %d", tosc_getNextInt32(osc)); break;
-      case 'h': printf(" %lld", tosc_getNextInt64(osc)); break;
-      case 't': printf(" %lld", tosc_getNextTimetag(osc)); break;
+      case 'h': printf(" %ld", tosc_getNextInt64(osc)); break;
+      case 't': printf(" %ld", tosc_getNextTimetag(osc)); break;
       case 's': printf(" %s", tosc_getNextString(osc)); break;
       case 'F': printf(" false"); break;
       case 'I': printf(" inf"); break;

--- a/zynlibs/zynmixer/mixer.c
+++ b/zynlibs/zynmixer/mixer.c
@@ -497,13 +497,13 @@ int init()
         g_dynamic[chan].phase = 0;
         g_dynamic[chan].enable_dpm = 1;
         char sName[10];
-        sprintf(sName, "input_%02da", chan + 1);
+        sprintf(sName, "input_%02lda", chan + 1);
         if (!(g_dynamic[chan].portA = jack_port_register(g_pJackClient, sName, JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0)))
         {
             fprintf(stderr, "libzynmixer: Cannot register %s\n", sName);
             exit(1);
         }
-        sprintf(sName, "input_%02db", chan + 1);
+        sprintf(sName, "input_%02ldb", chan + 1);
         if (!(g_dynamic[chan].portB = jack_port_register(g_pJackClient, sName, JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0)))
         {
             fprintf(stderr, "libzynmixer: Cannot register %s\n", sName);

--- a/zynlibs/zynseq/timebase.h
+++ b/zynlibs/zynseq/timebase.h
@@ -21,6 +21,7 @@
 
 #include "constants.h"
 #include <cstdint> //provides uint data types
+#include <cstddef>
 #include <vector>
 
 // Timebase event types

--- a/zynlibs/zynsmf/track.h
+++ b/zynlibs/zynsmf/track.h
@@ -3,6 +3,7 @@
 #include "event.h"
 #include <vector>
 #include <cstdint>
+#include <cstddef>
 
 class Track
 {

--- a/zynlibs/zynsmf/zynsmf.cpp
+++ b/zynlibs/zynsmf/zynsmf.cpp
@@ -696,7 +696,7 @@ double getTempo(Smf* pSmf, uint32_t nTime)
 
 void printEvents(Smf* pSmf, size_t nTrack)
 {
-	printf("Print events for track %u\n", nTrack);
+	printf("Print events for track %lu\n", nTrack);
 	if(!isSmfValid(pSmf))
 		return;
 	setPosition(pSmf, 0);


### PR DESCRIPTION
This PR allows to build zynthian-ui with the g++ version that comes with ubuntu Focal (g++ 11.4.0) and raspiOS Bookworm (g++ 12.2.0)