### PR TITLE
Allow moving processor in chain with encoder 3

### DIFF
--- a/zyngine/zynthian_chain_manager.py
+++ b/zyngine/zynthian_chain_manager.py
@@ -811,12 +811,13 @@ class zynthian_chain_manager:
 
     def nudge_processor(self, chain_id, processor, up):
         if (chain_id not in self.chains):
-            return None
+            return False
         chain = self.chains[chain_id]
-        if chain.nudge_processor(processor, up):
-            for src_chain in self.chains.values():
-                if chain_id in src_chain.audio_out:
-                    src_chain.rebuild_graph()
+        if not chain.nudge_processor(processor, up):
+            return False
+        for src_chain in self.chains.values():
+            if chain_id in src_chain.audio_out:
+                src_chain.rebuild_graph()
 
         if chain.mixer_chan is not None:
             # Audio chain so mute main output whilst making change (blunt but effective)
@@ -825,6 +826,7 @@ class zynthian_chain_manager:
             zynautoconnect.request_audio_connect(True)
             self.state_manager.zynmixer.set_mute(255, mute, False)
         zynautoconnect.request_midi_connect(True)
+        return True
 
     def remove_processor(self, chain_id, processor, stop_engine=True, autoroute=True):
         """Remove a processor from a chain

--- a/zyngui/zynthian_gui_chain_options.py
+++ b/zyngui/zynthian_gui_chain_options.py
@@ -202,6 +202,24 @@ class zynthian_gui_chain_options(zynthian_gui_selector):
 		else:
 			self.list_data[i][0](self.list_data[i][1], t)
 
+	# Function to handle zynpots value change
+	#   i: Zynpot index [0..n]
+	#   dval: Current value of zyncoder
+	def zynpot_cb(self, i, dval):
+		if i == 2:
+			try:
+				processor = self.list_data[self.index][1]
+				if processor is not None and self.zyngui.chain_manager.nudge_processor(self.chain_id, processor, dval < 0):
+					self.fill_list()
+					for index, data in enumerate(self.list_data):
+						if processor == data[1]:
+							self.select(index)
+							break
+			except:
+				pass # Ignore failure to move processor
+		else:
+			super().zynpot_cb(i, dval)
+
 	def arrow_right(self):
 		chain_keys = self.zyngui.chain_manager.ordered_chain_ids
 		try:


### PR DESCRIPTION
This PR allows use of the third encoder in the chain options menu to move a processor through the chain, giving a much more intutive interface. The submenu option remains to facilitate touch-only interface.