### PR TITLE
Fix copy pattern selection

### DIFF
--- a/zyngui/zynthian_gui_patterneditor.py
+++ b/zyngui/zynthian_gui_patterneditor.py
@@ -532,7 +532,7 @@ class zynthian_gui_patterneditor(zynthian_gui_base.zynthian_gui_base):
         elif params == 'Copy pattern':
             self.copy_source = self.pattern
             self.enable_param_editor(self, 'copy', {'name': 'Copy pattern to', 'value_min': 1,
-                                     'value_max': zynseq.SEQ_MAX_PATTERNS, 'value': self.pattern}, self.copy_pattern)
+                                     'value_max': zynseq.SEQ_MAX_PATTERNS, 'value': self.pattern, 'nudge_factor': 1}, self.copy_pattern)
         elif params == 'Load pattern':
             self.zyngui.screens['option'].config_file_list("Load pattern", [
                                                            self.patterns_dpath, self.my_patterns_dpath], "*.zpat", self.load_pattern_file)


### PR DESCRIPTION
This pull request fixes a problem I encountered when copying patterns: if you want to copy a pattern to another one whose number is close to it, it is not possible without this fix.

The cause of the problem is that the range of values for pattern number is so huge (from 1 to zynseq.SEQ_MAX_PATTERNS=64872) that when turning knobs # 3 and # 4 to define the destination pattern, you can only add 100 or 1000 to the current pattern, so it's impossible to add only 1 or 2 to the current pattern number.

With this fix I'm setting the `nudge_factor` to 1, so knob # 4 let's you add 1 to the current pattern and knob # 3 adds 100, making it possible to select any pattern number.

PD: A few months ago I reported another issue when copying patterns, I have the feeling I'm the only one using this feature! 😂 