### PR TITLE
LV2: Automatically detect fallback `showInterface` UI method.

### DIFF
--- a/zyngine/zynthian_lv2.py
+++ b/zyngine/zynthian_lv2.py
@@ -520,6 +520,10 @@ def is_plugin_ui(plugin):
                     res = "GtkUI"
                 elif ttl.find("X11UI") > 0 or ttl.find("X11") > 0:
                     res = "X11UI"
+                elif ttl.find("http://lv2plug.in/ns/extensions/ui#showInterface") > 0:
+                    # Fallback UI method when widget based methods are not available.
+                    # See: https://lv2plug.in/ns/extensions/ui#showInterface
+                    res = "UI"
                 else:
                     res = None
                 if res:


### PR DESCRIPTION
This enables jalv to automatically load the UI correctly for plugins that don't support one of the widget based variants.