### PR TITLE
Fix mod-ui autorouting

### DIFF
--- a/zynautoconnect/zynthian_autoconnect.py
+++ b/zynautoconnect/zynthian_autoconnect.py
@@ -915,7 +915,7 @@ def audio_autoconnect():
 
     # Remove mod-ui routes
     for dst in list(required_routes.keys()):
-        if dst.startswith("effect_"):
+        if dst.startswith("mod-monitor:"):
             required_routes.pop(dst)
 
     # Replicate main output to headphones


### PR DESCRIPTION
The logic to avoid connecting to mod-monitor inputs was already there but this must have regressed during the chain rewrite.  This change fixes mod-ui auto routing so that passthrough connections are managed only by the mod-ui graph.

Fixes: https://github.com/zynthian/zynthian-issue-tracking/issues/1316