### PR TITLE
Fix filename for headphones image

### DIFF
--- a/zyngui/zynthian_gui_admin.py
+++ b/zyngui/zynthian_gui_admin.py
@@ -169,11 +169,11 @@ class zynthian_gui_admin(zynthian_gui_selector_info):
             if zynthian_gui_config.rbpi_headphones:
                 self.list_data.append((self.stop_rbpi_headphones, 0, "\u2612 RBPi Headphones",
                                        ["Raspberry Pi onboard (low fidelity) headphone output is enabled",
-                                        "headphone.png"]))
+                                        "headphones.png"]))
             else:
                 self.list_data.append((self.start_rbpi_headphones, 0, "\u2610 RBPi Headphones",
                                        ["Raspberry Pi onboard (low fidelity) headphone output is disabled",
-                                        "headphone.png"]))
+                                        "headphones.png"]))
 
         self.list_data.append((self.hotplug_audio_menu, 0, "Hotplug USB Audio",
                                ["Configure USB audio hotplug.\n\nWhen enabled, USB audio devices will be detected and available. This does not include any device that is already configured as the main audio device which must always reamain connected.",


### PR DESCRIPTION
**Steps to reproduce**
On latest stable oram release or current vangelis:
1. Go to Webconf
2. Enable debug UI log messages
3. In the zynthian UI, go to Admin, Audio, select RBPi Headphones

**Actual result**
Debug log contains missing image message:

 `Jun 29 21:18:56 zynthian startx[4285]: ERROR:zynthian_gui_selector_info.get_icon: Can't load info icon headphone.png => [Errno 2] No such file or directory: '/zynthian/zynthian-ui/icons/headphone.png'`

**Expected result**
No error message and icon is used.

**Cause**
The image is called headphones.png, plural. 

**Note**
I haven't been able to test this, unclear yet what the best way is to do this. 