### PR TITLE
Internet Radio: Add break condition for closed connections. 

### DIFF
--- a/zyngine/zynthian_engine_inet_radio.py
+++ b/zyngine/zynthian_engine_inet_radio.py
@@ -126,7 +126,7 @@ class zynthian_engine_inet_radio(zynthian_engine):
                                   text=True, bufsize=1, stdout=PIPE, stderr=STDOUT, stdin=PIPE)
                 sleep(1)
                 self.client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                self.client.setblocking(False)
+                # self.client.setblocking(False) # Effect will be overridden by settimeout() in next line.
                 self.client.settimeout(1)
                 self.client.connect(("localhost", 4212)) #TODO Assign port in config
                 self.client.recv(4096)
@@ -177,7 +177,10 @@ class zynthian_engine_inet_radio(zynthian_engine):
             buffer = bytes()
             while True:
                 try:
-                    buffer += self.client.recv(1024)
+                    response = self.client.recv(1024)
+                    buffer += response
+                    if response == b'':
+                        break
                 except TimeoutError:
                     break
             if buffer:


### PR DESCRIPTION
This PR addresses the high CPU usage of `python3` observed after removing the Internet Radio chain, as reported in https://github.com/zynthian/zynthian-issue-tracking/issues/1437 .

The high CPU usage likely stems from the polling loop within `proc_poll_thread_task()`. It appears `socket.recv()` returns an empty byte array (e.g., `b''`) upon a closed connection, rather than raising a `TimeoutError`. To resolve this, I've added a break condition that exits the loop when `b''` is received, leading to reduced CPU usage in my testing.

Additionally, I've removed the redundant `socket.setblocking(False)` call, as its effect is overridden by the subsequent `socket.settimeout(1)`.