### PR TITLE
Akai APC Key25 Driver: add support for pattern template

### DIFF
--- a/zyngine/ctrldev/zynthian_ctrldev_akai_apc_key25_mk2.py
+++ b/zyngine/ctrldev/zynthian_ctrldev_akai_apc_key25_mk2.py
@@ -5,7 +5,7 @@
 #
 # Zynthian Control Device Driver for "Akai APC Key 25 mk2"
 #
-# Copyright (C) 2023,2024 Oscar Aceña <oscaracena@gmail.com>
+# Copyright (C) 2023-2025 Oscar Aceña <oscaracena@gmail.com>
 #
 # ******************************************************************************
 #
@@ -241,6 +241,8 @@ class zynthian_ctrldev_akai_apc_key25_mk2(zynthian_ctrldev_zynmixer, zynthian_ct
                 receiver, action, args, kwargs = action
                 if receiver == "stepseq":
                     self._stepseq_handler.run_action(action, args, kwargs)
+                elif receiver == "mixpad":
+                    self._padmatrix_handler.run_action(action, args, kwargs)
         return False
 
     def _on_midi_event(self, ev):
@@ -880,7 +882,7 @@ class MixerHandler(ModeHandlerBase):
 
 
 # --------------------------------------------------------------------------
-#  Handle pad matrix for Zynseq (in Mixpad mode)
+# Handle pad matrix for Zynseq (in Mixpad mode)
 # --------------------------------------------------------------------------
 class PadMatrixHandler(ModeHandlerBase):
 
@@ -915,6 +917,7 @@ class PadMatrixHandler(ModeHandlerBase):
         self._track_btn_pressed = None
         self._playing_seqs = set()
         self._btn_timer = ButtonTimer(self._handle_timed_button)
+        self._pattern_template = None
 
         # Seqman sub-mode
         self._seqman_func = None
@@ -1262,6 +1265,9 @@ class PadMatrixHandler(ModeHandlerBase):
             self._libseq.addPattern(scene, seq, 0, 0, pattern)
             self._libseq.selectPattern(pattern)
 
+            if self._pattern_template is not None:
+                self._action_apply_pattern_template(pattern)
+
     def _copy_sequence(self, src_scene, src_seq, dst_scene, dst_seq):
         self._clear_sequence(dst_scene, dst_seq, create_empty=False)
 
@@ -1293,6 +1299,12 @@ class PadMatrixHandler(ModeHandlerBase):
         # Also copy StepSeq instrument pages
         self._request_action("stepseq", "sync-sequences",
             src_scene, src_seq, dst_scene, dst_seq)
+
+    def _action_set_pattern_template(self, pattern):
+        self._pattern_template = pattern
+
+    def _action_apply_pattern_template(self, dst_pattern):
+        self._libseq.copyPattern(self._pattern_template, dst_pattern)
 
 
 # --------------------------------------------------------------------------
@@ -1390,7 +1402,7 @@ class StepSyncProvider(mp.Process):
 
 
 # --------------------------------------------------------------------------
-#  Step Sequencer clock sync
+# Step Sequencer clock sync
 # --------------------------------------------------------------------------
 class StepSyncConsumer(Thread):
     def __init__(self, event_queue, callback):
@@ -1408,8 +1420,8 @@ class StepSyncConsumer(Thread):
 
 
 # --------------------------------------------------------------------------
-#  Class to hold instrument pads for StepSeq (a.k.a. note-pads)
-#  Note: it inherits from dict to be json-serializable and easily comparable
+# Class to hold instrument pads for StepSeq (a.k.a. note-pads)
+# Note: it inherits from dict to be json-serializable and easily comparable
 # --------------------------------------------------------------------------
 class NotePad(dict):
     def __init__(self, note, velocity, duration=1, stutter_count=0, stutter_duration=1):
@@ -1433,8 +1445,8 @@ class NotePad(dict):
 
 
 # --------------------------------------------------------------------------
-#  Class to marshall/un-marshall saved state of StepSeq
-#  FIXME: add support for scenes too!
+# Class to marshall/un-marshall saved state of StepSeq
+# FIXME: add support for scenes too!
 # --------------------------------------------------------------------------
 class StepSeqState:
     def __init__(self):
@@ -1475,7 +1487,7 @@ class StepSeqState:
 
 
 # --------------------------------------------------------------------------
-#  Note objects used in NotePlayer's event queue
+# Note objects used in NotePlayer's event queue
 # --------------------------------------------------------------------------
 class Note:
     def __init__(self, note, velocity, duration_cycles, channel, stutt_count, stutt_duration):
@@ -1539,8 +1551,8 @@ class Note:
 
 
 # --------------------------------------------------------------------------
-#  Note player (adds support for stutter, is also quantized)
-#  FIXME: if jack is playing, synchronize with it
+# Note player (adds support for stutter, is also quantized)
+# FIXME: if jack is playing, synchronize with it
 # --------------------------------------------------------------------------
 class NotePlayer(Thread):
     def __init__(self, libseq):
@@ -1616,7 +1628,7 @@ class NotePlayer(Thread):
 
 
 # --------------------------------------------------------------------------
-#  Step Sequencer mode (StepSeq)
+# Step Sequencer mode (StepSeq)
 # --------------------------------------------------------------------------
 class StepSeqHandler(ModeHandlerBase):
     PAD_COLS = 8
@@ -1646,6 +1658,7 @@ class StepSeqHandler(ModeHandlerBase):
         self._selected_seq = None
         self._selected_pattern = None
         self._selected_pattern_idx = 0
+        self._pattern_template = None
         self._selected_note = None
         self._pattern_clock_offset = 0
         self._used_pads = 32
@@ -1712,6 +1725,9 @@ class StepSeqHandler(ModeHandlerBase):
 
         if self._is_arranger_mode:
             self._leds.led_blink(BTN_SOFT_KEY_SELECT)
+
+        if self._selected_pattern == self._pattern_template:
+            self._leds.led_blink(BTN_SOFT_KEY_REC_ARM)
 
     def _refresh_note_pads(self):
         # If there is a note config controller, it will handle all pads, nothing to do here
@@ -1805,7 +1821,7 @@ class StepSeqHandler(ModeHandlerBase):
                 if BTN_PAD_START <= note <= BTN_PAD_END:
                     return self._note_config.note_on(note, velocity, self._is_shifted)
             elif BTN_PAD_START <= note <= BTN_PAD_START + 7:
-                if not self._is_arranger_mode and self._note_config is None:
+                if not self._is_arranger_mode:
                     self._change_instrument(note)
             elif note == BTN_LEFT:
                 self._change_to_previous_pattern()
@@ -1814,6 +1830,15 @@ class StepSeqHandler(ModeHandlerBase):
             elif note == BTN_SOFT_KEY_SELECT:
                 self._is_select_pressed = True
                 self._enable_arranger_mode(True)
+
+            elif note == BTN_SOFT_KEY_REC_ARM:
+                new_template = self._selected_pattern
+                if new_template == self._pattern_template:
+                    new_template = None
+                self._pattern_template = new_template
+                self._request_action(
+                    "mixpad", "set-pattern-template", new_template)
+
             elif note == BTN_PLAY:
                 self._libseq.togglePlayState(
                     self._zynseq.bank, self._selected_seq)
@@ -1822,6 +1847,7 @@ class StepSeqHandler(ModeHandlerBase):
                 if state in (zynseq.SEQ_STARTING, zynseq.SEQ_PLAYING, zynseq.SEQ_RESTARTING):
                     self._is_stage_play = True
                     self.refresh()
+
             elif note == BTN_UP:
                 self._state_manager.send_cuia("BACK")
             elif note == BTN_DOWN:
@@ -2142,9 +2168,9 @@ class StepSeqHandler(ModeHandlerBase):
             if self._is_arranger_mode and len(self._pressed_pads) == 2:
                 src_idx = next(
                     pad for pad in self._pressed_pads if pad != dst_idx)
-                self._copy_pattern(src_idx, dst_idx)
-                self._leds.led_on(note, COLOR_LIME,
-                                  LED_BLINKING_16, overlay=True)
+                if self._copy_pattern(src_idx, dst_idx):
+                    self._leds.led_on(note, COLOR_LIME,
+                        LED_BLINKING_16, overlay=True)
                 self._leds.delayed("remove_overlay", 1000, note)
             elif self._note_pads_function == FN_SELECT_PATTERN:
                 if dst_idx < len(self._sequence_patterns):
@@ -2369,6 +2395,7 @@ class StepSeqHandler(ModeHandlerBase):
         track = 0
 
         if self._selected_pattern_idx < 7:
+            roll_pattern = self._is_select_pressed
             if self._selected_pattern_idx >= len(self._sequence_patterns) - 1:
                 # Create a new pattern only if SHIFT is pressed
                 if not self._is_shifted:
@@ -2378,18 +2405,25 @@ class StepSeqHandler(ModeHandlerBase):
                     logging.error(" could not add a new pattern!")
                     return
                 self._sequence_patterns.append(pattern)
+                if self._pattern_template is not None and not roll_pattern:
+                    self._request_action(
+                        "mixpad", "apply-pattern-template", pattern)
 
             self._change_to_pattern_index(
                 self._selected_pattern_idx,
                 self._selected_pattern_idx + 1,
-                self._is_select_pressed)
+                roll_pattern)
         self._show_patterns_bar()
 
     def _copy_pattern(self, from_idx, to_idx):
+        if to_idx >= len(self._sequence_patterns):
+            return False
+
         self._libseq.copyPattern(
             self._sequence_patterns[from_idx],
             self._sequence_patterns[to_idx])
         self._libseq.updateSequenceInfo()
+        return True
 
     def _clear_pattern(self, index):
         current = self._libseq.getPatternIndex()
@@ -2533,8 +2567,8 @@ class StepSeqHandler(ModeHandlerBase):
 
 
 # --------------------------------------------------------------------------
-#  Class to access individual steps using the same interface that pads uses,
-#  to be used by StepSeq's PropertyControls
+# Class to access individual steps using the same interface that pads uses,
+# to be used by StepSeq's PropertyControls
 # --------------------------------------------------------------------------
 class StepProxy:
     def __init__(self, libseq, note, step):
@@ -2574,7 +2608,7 @@ class StepProxy:
 
 
 # --------------------------------------------------------------------------
-#  Base of controller utilities to change some property of a NotePad/Step
+# Base of controller utilities to change some property of a NotePad/Step
 # --------------------------------------------------------------------------
 class BaseControl:
     KIND = "undefined"
@@ -2675,7 +2709,7 @@ class BaseControl:
 
 
 # --------------------------------------------------------------------------
-#  A controller utility to change velocity of a NotePad/Step
+# A controller utility to change velocity of a NotePad/Step
 # --------------------------------------------------------------------------
 class VelocityControl(BaseControl):
     KIND = "velocity"
@@ -2693,7 +2727,7 @@ class VelocityControl(BaseControl):
 
 
 # --------------------------------------------------------------------------
-#  A controller utility to change stutter count of a NotePad/Step
+# A controller utility to change stutter count of a NotePad/Step
 # --------------------------------------------------------------------------
 class StutterCountControl(BaseControl):
     KIND = "stutter-count"
@@ -2711,7 +2745,7 @@ class StutterCountControl(BaseControl):
 
 
 # --------------------------------------------------------------------------
-#  A controller utility to change stutter duration of a NotePad/Step
+# A controller utility to change stutter duration of a NotePad/Step
 # --------------------------------------------------------------------------
 class StutterDurationControl(BaseControl):
     KIND = "stutter-duration"

--- a/zyngine/ctrldev/zynthian_ctrldev_base_extended.py
+++ b/zyngine/ctrldev/zynthian_ctrldev_base_extended.py
@@ -117,7 +117,7 @@ class RunTimer(Thread):
 
 
 # --------------------------------------------------------------------------
-#  A timer for running repeated actions
+# A timer for running repeated actions
 # --------------------------------------------------------------------------
 class IntervalTimer(RunTimer):
     RESOLUTION = 0.05
@@ -276,6 +276,10 @@ class ModeHandlerBase:
         self._is_shifted = False
         self._is_active = False
 
+    @property
+    def name(self):
+        return self.__class__.__name__
+
     def refresh(self):
         """Overwrite in derived class if needed."""
 
@@ -319,14 +323,16 @@ class ModeHandlerBase:
             return None
         return self._pending_actions.pop(0)
 
-    def run_action(self, action, args, kwargs):
-        action = "_action_" + action.replace("-", "_")
-        action = getattr(self, action, None)
+    def run_action(self, action_name, args, kwargs):
+        action_name = "_action_" + action_name.replace("-", "_")
+        action = getattr(self, action_name, None)
         if callable(action):
             try:
                 action(*args, **kwargs)
             except Exception as ex:
-                logging.error(f" error in handler: {ex}")
+                logging.error(f"error in handler: {ex}")
+        else:
+            logging.warning(f"missing action '{action_name}' in handler '{self.name}'")
 
     def _request_action(self, receiver, action, *args, **kwargs):
         self._pending_actions.append((receiver, action, args, kwargs))


### PR DESCRIPTION
This PR allows the user to select a pattern as template, which will be automatically used when a new pattern is created. Fixes #zynthian/zynthian-issue-tracking/issues/1441