### PR TITLE
Fix race condition loading plugins with both controllers and presets.

### DIFF
--- a/zyngine/zynthian_engine_jalv.py
+++ b/zyngine/zynthian_engine_jalv.py
@@ -167,6 +167,8 @@ class zynthian_engine_jalv(zynthian_engine):
         self.save_bank = None
         self.save_preset_uri = None
 
+        self.expecting_ctrls = False
+
         if state_manager:
             self.eng_info = self.state_manager.chain_manager.engine_info[eng_code]
         else:
@@ -394,6 +396,7 @@ class zynthian_engine_jalv(zynthian_engine):
                     logging.debug(f"LOG {self.jackname} > " + line)
 
     def proc_parse_ctrl_value(self, line):
+        self.expecting_ctrls = False
         parts = line.split("=")
         if len(parts) == 2:
             symparts = parts[0].split("#", maxsplit=1)
@@ -587,6 +590,8 @@ class zynthian_engine_jalv(zynthian_engine):
     def set_preset(self, processor, preset, preload=False):
         if not preset[0]:
             return
+        # The `preset` command will print all controllers.
+        self.expecting_ctrls = True
         self.proc_cmd(f"preset {preset[0]}")
         return True
 
@@ -902,6 +907,15 @@ class zynthian_engine_jalv(zynthian_engine):
                 self.proc_cmd("%s=%s" % (zctrl.symbol, zctrl.value))
             else:
                 self.proc_cmd("%s=%.6f" % (zctrl.symbol, zctrl.value))
+
+        if self.expecting_ctrls:
+            # If we are expecting controllers values over the process pipe, but
+            # we just updated the controllers here, then there is a chance that
+            # the controller values coming from the pipe contain the old values
+            # from before this update, which will lead to the UI getting out of
+            # sync with the plugin. So schedule a new listing of the controller
+            # values to force a refresh.
+            self.proc_cmd("controls")
 
     # ---------------------------------------------------------------------------
     # API methods


### PR DESCRIPTION
The race condition can happen when restoring a snapshot, and a plugin both has a preset and controller values. What is supposed to happen is this:

1. Jalv is told to load a preset.

2. Jalv prints the controllers associated with that preset, which is picked up on the process pipe. This causes an update in the UI.

3. New controller values are set based on what was stored in the snapshot, which updates the plugin, and again the UI.

Because the the parsing of the Jalv messages in point 2 happens in a separate thread, it's possible for step 2 and 3 to be reversed. In this case it will cause the UI to go out of sync with the plugin, since the printout from Jalv contains the values from the preset, not the ones that were set most recently.

At that moment it is only a display issue, since the plugin will actually be using the correct values. But the values in the UI are the ones that are saved, so if the snapshot is saved again, the plugin parameters will be wrong the next time the snapshot is loaded.

Fix this by forcing another controller printout from Jalv if we update any controller values while we are still waiting for one.

Fixes:
https://github.com/zynthian/zynthian-issue-tracking/issues/1453