### PR TITLE
zynthian_engine_jalv: Add controls for JV-880

### DIFF
--- a/zyngine/zynthian_engine_jalv.py
+++ b/zyngine/zynthian_engine_jalv.py
@@ -128,8 +128,11 @@ class zynthian_engine_jalv(zynthian_engine):
             'volume': [7, 98],
             'panning': [10, 64],
             'modulation wheel': [1, 0],
+            'expression': [11, 64],
             'filter cutoff': [74, 64],
-            'filter resonance': [71, 64]
+            'filter resonance': [71, 64],
+            'reverb': [91, 127],
+            'chorus': [93, 127]
         },
         "ctrl_screens": {
             '_default_synth': ['modulation wheel'],
@@ -153,6 +156,7 @@ class zynthian_engine_jalv(zynthian_engine):
             'synthv1': [],
             'Surge': ['modulation wheel'],
             'padthv1': [],
+            'VirtualJV': ['modulation wheel', 'expression', 'reverb', 'chorus'],
             'Vex': [],
             'amsynth': ['modulation wheel'],
             'JC303': [],


### PR DESCRIPTION
Add Expression, Reverb and Chorus real-time controls for JV-880, in addition to the already existing Modulation Wheel.

Reverb and Chorus are on/off parameters, but I don't know if zynthian_engine_jalv supports this, so they are displayed as ordinary (value range 0-127) continuous parameters.

JV-880 also supports portamento on/off (CC 65), pan (CC 10) and volume (CC 7), but I opted not to include them because pan and volume are normally controlled from the mixer view, and it's relatively unusual to use portamento, so I opted for a total of four parameters that can be shown on a single page.