### PR TITLE
fix: map F11 and F12 in keybindings

### DIFF
--- a/zyngui/zynthian_gui_keybinding.py
+++ b/zyngui/zynthian_gui_keybinding.py
@@ -205,6 +205,11 @@ def get_key_action(keycode, modifier):
     logging.debug(
         f"Get keybinding function name for keycode: {keycode}, modifier: {modifier}")
     try:
+        # Hotfix: Map F11 and F12
+        if keycode == 95:
+            keycode = 77
+        if keycode == 96:
+            keycode = 78
         # Check for defined modifier
         if keycode in [63, 77, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 104, 106]:
             modifier &= 253


### PR DESCRIPTION
F11 and F12 usually get the keycodes 95 and 96. This minor fix maps these values to 77 and 78 which are used by zynthian-ui for the respective keys. Re-mapping at runtime ensures backwards compatibility.