### PR TITLE
Enable arrow up/down for all instances of param editor

### DIFF
--- a/zyngui/zynthian_gui_mixer.py
+++ b/zyngui/zynthian_gui_mixer.py
@@ -2141,7 +2141,9 @@ class zynthian_gui_mixer(zynthian_gui_base):
     def arrow_up(self, nudge=1):
         """ Function to handle CUIA ARROW_UP
         """
-        if self.launcher_mode:
+        if self.param_editor_zctrl:
+            self.zynpot_cb(self.ctrl_order[3], 1)
+        elif self.launcher_mode:
             if self.zynseq.phrase > 0:
                 if self.moving_phrase:
                     self.zynseq.swap_phrase(self.zynseq.scene, self.zynseq.phrase, self.zynseq.phrase - nudge)
@@ -2156,7 +2158,9 @@ class zynthian_gui_mixer(zynthian_gui_base):
     def arrow_down(self, nudge=-1):
         """ Function to handle CUIA ARROW_DOWN
         """
-        if self.launcher_mode:
+        if self.param_editor_zctrl:
+            self.zynpot_cb(self.ctrl_order[3], -1)
+        elif self.launcher_mode:
             if self.zynseq.phrase < self.zynseq.phrases:
                 if self.moving_phrase:
                     if self.zynseq.phrase < self.zynseq.phrases - 1:

--- a/zyngui/zynthian_gui_selector.py
+++ b/zyngui/zynthian_gui_selector.py
@@ -55,6 +55,7 @@ class zynthian_gui_selector(zynthian_gui_base):
         if "ctrl_width" not in self.layout:
             self.layout['ctrl_width'] = 0.25
 
+        self.ctrl_order = zynthian_gui_config.layout['ctrl_order']
         self.index = 0
         self.scroll_y = 0
         self.list_data = []
@@ -421,10 +422,16 @@ class zynthian_gui_selector(zynthian_gui_base):
         return False
 
     def arrow_up(self):
-        self.select(self.index - 1)
+        if self.param_editor_zctrl:
+            self.zynpot_cb(self.ctrl_order[3], 1)
+        else:
+            self.select(self.index - 1)
 
     def arrow_down(self):
-        self.select(self.index + 1)
+        if self.param_editor_zctrl:
+            self.zynpot_cb(self.ctrl_order[3], -1)
+        else:
+            self.select(self.index + 1)
 
     # --------------------------------------------------------------------------
     # Keyboard & Mouse/Touch Callbacks


### PR DESCRIPTION
Implements https://github.com/zynthian/zynthian-issue-tracking/issues/1586 as far as I can see.

Enabling arrow keys to edit the values in a param editor (the ephemeral editor at the top of the screen invoked mainly from menus) everywhere on Zynthian.

The other [PR](https://github.com/zynthian/zynthian-ui/pull/553) was not branched of oram, but when creating the PR, github defaults to the default branch, should set vangelis explicitly. Just rebased on latest vangelist for good measure. It's a single commit.