### PR TITLE
Add cuia to copy/paste patterns (or other stuff)

### DIFF
--- a/zyngui/zynthian_gui.py
+++ b/zyngui/zynthian_gui.py
@@ -1417,6 +1417,12 @@ class zynthian_gui:
     def cuia_tap_tempo(self, params=None):
         self.state_manager.zynseq.tap_tempo()
 
+    def cuia_copy(self, params=None):
+        pass
+
+    def cuia_paste(self, params=None):
+        pass
+
     # Zynpot & Zynswitch emulation CUIAs (low level)
     def cuia_zynpot(self, params=None):
         try:

--- a/zyngui/zynthian_gui_pated_base.py
+++ b/zyngui/zynthian_gui_pated_base.py
@@ -1699,6 +1699,14 @@ class zynthian_gui_pated_base(zynthian_gui_base):
         self.toggle_playback()
         return True
 
+    def cuia_copy(self, params=None):
+        self.copy_pattern(params[0])
+        return True
+
+    def cuia_paste(self, params=None):
+        self.paste_pattern(params[0])
+        return True
+
     def update_wsleds(self, leds):
         wsl = self.zyngui.wsleds
 


### PR DESCRIPTION
Adds CUIA actions to copy / paste.

Only added an implementation in pattern editor, to interface the new copy/paste patterns. Since that is the only place the copy/paste paradigm currently exists.

Scratches these itches:
- Being less bound to the UI when implementing the ALT F1-F4 bindings in pattern editor in a deviceMode such as in the the APCKey25 drivers.
- If we have this, people could also for instance keyboard-bind Ctrl-C/Ctrl-V to this. 

## Alternatives considered:

- High-level CUIA bindings for all v5 buttons
  e.g. cuia_v5_btn_opt_admin, cuia_v5_btn_f1 etc. Or cuia_v5_btn with params. Which should take care of short, bold, long, and effective alt mode. This would really decouple deviceModes from the UI (but tie them to the V5 button layout, which they now re-implement), and could be a welcome addition for (numpad) keyboard bindings too. Please lead me in the right direction if something like that is already in place, but just hard to be found in docs/code.

- Calling pattern editor screen directly from the device driver.