### PR TITLE
Cast clipboard param to int

### DIFF
--- a/zyngui/zynthian_gui_pated_base.py
+++ b/zyngui/zynthian_gui_pated_base.py
@@ -2057,11 +2057,11 @@ class zynthian_gui_pated_base(zynthian_gui_base):
         return True
 
     def cuia_copy(self, params=None):
-        self.copy_pattern(params[0])
+        self.copy_pattern(int(params[0]))
         return True
 
     def cuia_paste(self, params=None):
-        self.paste_pattern(params[0])
+        self.paste_pattern(int(params[0]))
         return True
 
     def update_wsleds(self, leds):


### PR DESCRIPTION
    Wouldn't work from HID keyboard binding. That is received as a string, therefore no viable index.