### PR TITLE
Help suggestion: Use Index title instead of INDEX

### DIFF
--- a/zyngui/zynthian_gui_help.py
+++ b/zyngui/zynthian_gui_help.py
@@ -126,7 +126,7 @@ class zynthian_gui_help:
   <link rel="stylesheet" href="{self.ui_dir}/help/style.css">
  </head>
  <body>
-  <h1>INDEX</h1>
+  <h1>Index</h1>
    <ul class="index">
 """
 


### PR DESCRIPTION
It's already an H1 and I feel it's more fitting with the overall Zynthian titles. Moreover, it feels less like shouting 😎.