### PR TITLE
Fix typo in tempo view help

### DIFF
--- a/help/core/tempo.html
+++ b/help/core/tempo.html
@@ -5,7 +5,7 @@
 
  <body>
  <h1>Tempo View</h1>
-    <p>The tempo view provides control of zynthian's timebase used for sequencing, arpeggiator, etc.</p>
+    <p>The tempo view provides control of zynthian's timebase used for sequencing, arpeggiators, etc.</p>
     <p>The BPM control sets the internal tempo between the values of 10 and 420 BPM. Push and rotate to adjust in 0.1 BPM steps. This control is available if using internal clock.</p>
     <p> If external clock is used, the BPM control changes to be a clock divider. By default it expects a 24 PPQN input which is what MIDI clock uses but may be adjusted to support other external clock rates in the range 1 to 48 PPQN. The internal clock runs at 1920 PPQN and uses a phase locked loop to derive this high resolution clock from the slow input clock. To use an external clock, select "MIDI Clock Source" for a MIDI input in the <a href="chain_midi_input.html">MIDI Input</a> view.</p>
     <p>The Metronome Mode control configures the zynthian's metronome. It has these values:

--- a/help/core/tempo.html
+++ b/help/core/tempo.html
@@ -5,7 +5,7 @@
 
  <body>
  <h1>Tempo View</h1>
-    <p>The tempo view provides control of zynthian's timebase used for sequencing, arpreggiators, etc.</p>
+    <p>The tempo view provides control of zynthian's timebase used for sequencing, arpeggiator, etc.</p>
     <p>The BPM control sets the internal tempo between the values of 10 and 420 BPM. Push and rotate to adjust in 0.1 BPM steps. This control is available if using internal clock.</p>
     <p> If external clock is used, the BPM control changes to be a clock divider. By default it expects a 24 PPQN input which is what MIDI clock uses but may be adjusted to support other external clock rates in the range 1 to 48 PPQN. The internal clock runs at 1920 PPQN and uses a phase locked loop to derive this high resolution clock from the slow input clock. To use an external clock, select "MIDI Clock Source" for a MIDI input in the <a href="chain_midi_input.html">MIDI Input</a> view.</p>
     <p>The Metronome Mode control configures the zynthian's metronome. It has these values:
@@ -14,7 +14,7 @@
          <li>AUTO: Metronome will sound when there is a sequence playing and stop at the end of the bar after the last sequence stops.</li>
          <li>ON: Metronome plays continuously.</li>
          <li>INTRO: Metronome plays until a sequence starts. You may use this as a count-in when you don't want or need the metronome to play during performance.</li>
-         <li>NO ACCENT: Metronome plays continulaly but with without an accent on the first beat of each bar. This acts more like a traditional metronome used purely for tempo and not timebase.</li>
+         <li>NO ACCENT: Metronome plays continually but with without an accent on the first beat of each bar. This acts more like a traditional metronome used purely for tempo and not timebase.</li>
          <li>SILENT: Metronome runs but does not make any sound. This can be useful to cause the transport to run when there are no sequences running. Some plugins may benefit from this.</li>
       </ul>
       There is a control to adjust the metronome volume level.</p>


### PR DESCRIPTION
On a side note, I see the link (href) to MIDI Input, which doesn't seem to react when tapped on a V4.
@riban-bw 
