### PR TITLE
Fix typo in MIDI key range description

### DIFF
--- a/help/core/midi_key_range.html
+++ b/help/core/midi_key_range.html
@@ -5,7 +5,7 @@
 
  <body>
  <h1>MIDI Key Range and Transpose</h1>
-   <p>This view allows configuration of the keyrange and transpose of MIDI notes for a chain. This applies to all MIDI note messages reaching the chain.</p>
+   <p>This view allows configuration of the key range and transpose of MIDI notes for a chain. This applies to all MIDI note messages reaching the chain.</p>
    <h2>Key Range</h2>
    <p>A piano keyboard is displayed, showing the range of notes that will pass to the chain. Greyed out notes are blocked. Knobs 3 &amp; 4 adjust the lower and upper limits of the range. Pressing knob 3 enables MIDI learn, allowing the lower and then the upper limits to be set by sending the corresponding MIDI notes. You may also use the touchscreen to drag the range onto the on-screen keyboard.</p>
    <h2>Transpose</h2>


### PR DESCRIPTION
Make it consistent with page title.