### PR TITLE
Fix typo in capture workflow title

### DIFF
--- a/zyngui/zynthian_gui.py
+++ b/zyngui/zynthian_gui.py
@@ -217,7 +217,7 @@ class zynthian_gui:
     # Capture Log
     # ---------------------------------------------------------------------------
 
-    def start_capture_log(self, title="ui_sesion"):
+    def start_capture_log(self, title="ui_session"):
         now = datetime.now()
         self.capture_log_ts0 = now
         self.capture_log_fname = f"{title}-{now.strftime('%Y%m%d%H%M%S')}"
@@ -1266,7 +1266,7 @@ class zynthian_gui:
     def cuia_last_state_action(self, params=None):
         self.screens['admin'].last_state_action()
 
-    def cuia_workflow_capture_start(self, params=["ui_sesion"]):
+    def cuia_workflow_capture_start(self, params=["ui_session"]):
         self.start_capture_log(params[0])
 
     def cuia_workflow_capture_stop(self, params=None):


### PR DESCRIPTION
Change 'ui_sesion' to 'ui_session'

Fixes https://github.com/zynthian/zynthian-issue-tracking/issues/1639

Verified with a new capture on latest vangelis + this change:

1. Capture filename now contains ui_session (double s)
<img width="460" height="640" alt="image" src="https://github.com/user-attachments/assets/6f505001-0613-4e28-9b70-cc331b6039df" />

2. Mockup player title is now showing ui_session (double s)
<img width="1134" height="421" alt="image" src="https://github.com/user-attachments/assets/5ce8ebbd-d49d-4eb3-92b5-2f54ade5ed94" />

