### PR TITLE
Fix argument in call

### DIFF
--- a/zyngui/zynthian_gui_pated_base.py
+++ b/zyngui/zynthian_gui_pated_base.py
@@ -2018,7 +2018,7 @@ class zynthian_gui_pated_base(zynthian_gui_base):
 
     def start_playback(self):
         # Set to start of pattern - work around for timebase issue in library.
-        self.zynseq.libseq.setSequencePlayPosition(self.phrase, self.sequence, 0)
+        self.zynseq.libseq.setSequencePlayPosition(self.zynseq.scene, self.phrase, self.sequence, 0)
         self.zynseq.libseq.setPlayState(self.zynseq.scene, self.phrase, self.sequence, zynseq.SEQ_STARTING)
 
     def stop_playback(self):


### PR DESCRIPTION
Arguments to self.zynseq.libseq.setSequencePlayPosition were wrong.

This causes rec+pad in akai apc key25 to have a wrong playhead.