### PR TITLE
Use internal zynseq method to check emptiness

### DIFF
--- a/zyngui/zynthian_gui_mixer.py
+++ b/zyngui/zynthian_gui_mixer.py
@@ -263,8 +263,8 @@ class zynthian_gui_launcher_pad():
                         n_beats = self.gui_mixer.zynseq.libseq.getBeatsInPattern(pattern)
                         timesig_text = self.get_pattern_length(n_beats, state_phrase["bpb"])
                         try:
-                            empty = len(self.gui_mixer.zynseq.state["patns"][str(pattern)]["events"]) == 0
-                        except:
+                            empty = self.gui_mixer.zynseq.libseq.isEmpty(self.gui_mixer.zynseq.scene, self.phrase, self.chain.midi_chan)
+                        except Exception as e:
                             empty = True
                     except Exception as e:
                         logging.error(e)


### PR DESCRIPTION
The manual way did not work anymore. Cannot remember whether it threw an error or reported incorrectly.

Any way, deferring to dedicated and explicit api is better.

Found this while working on porting apc key25 driver. GUI did not reflect pattern empty/fullness without this.