### PR TITLE
1638/midi cc in zs3

### DIFF
--- a/zyngine/zynthian_state_manager.py
+++ b/zyngine/zynthian_state_manager.py
@@ -1338,8 +1338,18 @@ class zynthian_state_manager:
     def set_zs3_title(self, zs3_id, title):
         self.zs3[zs3_id]["title"] = title
 
-    def toggle_zs3_restore_flag(self, zs3_id, type, id):
+    def toggle_zs3_restore_flag(self, zs3_id, type, id=None):
         zs3_state = self.zs3[zs3_id]
+        if type == "midi_learn":
+            val = zs3_state.get("restore_midi_learn", None)
+            if val == None:
+                val = True
+            elif val == True:
+                val = False
+            else:
+                val = None
+            zs3_state["restore_midi_learn"] = val
+            return
         try:
             tstate = zs3_state[type][int(id)]
         except:
@@ -1349,13 +1359,6 @@ class zynthian_state_manager:
         except:
             tstate["restore"] = False
 
-    def toggle_zs3_store_midi_learn(self, zs3_id):
-        if zs3_id == "zs3-0" or zs3_id not in self.zs3:
-            return
-        try:
-            self.zs3[zs3_id].pop("store_midi_learn")
-        except:
-            self.zs3[zs3_id]["store_midi_learn"] = True
 
     def load_zs3(self, zs3_id, autoconnect=True):
         """Restore a ZS3
@@ -1388,6 +1391,7 @@ class zynthian_state_manager:
 
         restored_chains = []
         restored_cc_mapping = []
+        restore_midi_learn = zs3_state.get("restore_midi_learn", None)
         mute_pause = False
         if "chains" in zs3_state:
             self.set_busy_details("restoring chains state")
@@ -1445,29 +1449,30 @@ class zynthian_state_manager:
                             chain.audio_out.append(out)
                 chain.rebuild_graph()
 
-                # Restore CC binding if configured, else use default from zs3-0
-                if "midi_learn" in chain_state or "midi_cc" in chain.state:
+                ml_chain_state = None
+                if restore_midi_learn:
                     ml_chain_state = chain_state
-                else:
-                    ml_chain_state = self.zs3["zs3-0"]
-                # Current (correct) chain MIDI-learn state
-                self.chain_manager.clean_midi_learn(chain_id)
-                if "midi_learn" in ml_chain_state:
-                    for low_key, cfg in ml_chain_state["midi_learn"].items():
-                        low_key = int(low_key)
-                        midi_chan = (low_key >> 8) & 0xff
-                        midi_cc = low_key & 0x7f
-                        for proc_id, symbol in cfg:
-                            if proc_id in self.chain_manager.processors:
-                                restored_cc_mapping.append((proc_id, symbol, midi_chan, midi_cc))
-                # Legacy (wrong) chain MIDI-learn state
-                elif "midi_cc" in ml_chain_state:
-                    for midi_cc, cfg in ml_chain_state["midi_cc"].items():
-                        midi_chan = 0xff
-                        midi_cc = int(midi_cc) & 0x7f
-                        for proc_id, symbol in cfg:
-                            if proc_id in self.chain_manager.processors:
-                                restored_cc_mapping.append((proc_id, symbol, midi_chan, midi_cc))
+                elif restore_midi_learn is None and chain_id in self.zs3["zs3-0"]["chains"]:
+                    ml_chain_state = self.zs3["zs3-0"]["chains"][chain_id]
+                if ml_chain_state:
+                    # Current (correct) chain MIDI-learn state
+                    self.chain_manager.clean_midi_learn(chain_id)
+                    if "midi_learn" in ml_chain_state:
+                        for low_key, cfg in ml_chain_state["midi_learn"].items():
+                            low_key = int(low_key)
+                            midi_chan = (low_key >> 8) & 0xff
+                            midi_cc = low_key & 0x7f
+                            for proc_id, symbol in cfg:
+                                if proc_id in self.chain_manager.processors:
+                                    restored_cc_mapping.append((proc_id, symbol, midi_chan, midi_cc))
+                    # Legacy (wrong) chain MIDI-learn state
+                    elif "midi_cc" in ml_chain_state:
+                        for midi_cc, cfg in ml_chain_state["midi_cc"].items():
+                            midi_chan = 0xff
+                            midi_cc = int(midi_cc) & 0x7f
+                            for proc_id, symbol in cfg:
+                                if proc_id in self.chain_manager.processors:
+                                    restored_cc_mapping.append((proc_id, symbol, midi_chan, midi_cc))
 
         if mute_pause:
             # Wait for soft mutes to apply before changing settings
@@ -1505,7 +1510,7 @@ class zynthian_state_manager:
 
         if "midi_capture" in zs3_state:
             self.set_busy_details("restoring midi capture state")
-            self.set_midi_capture_state(zs3_state['midi_capture'])
+            self.set_midi_capture_state(zs3_state['midi_capture'], restore_midi_learn=restore_midi_learn!=False)
 
         if "global" in zs3_state:
             try:
@@ -1604,6 +1609,7 @@ class zynthian_state_manager:
         # Store persistent config
         omit_processors = []
         omit_chains = []
+        restore_midi_learn = None
         if zs3_id in self.zs3:
             zs3 = self.zs3[zs3_id]
             if "processors" in zs3:
@@ -1614,19 +1620,16 @@ class zynthian_state_manager:
                 for chain_id, chain in zs3["chains"].items():
                     if "restore" in chain and not chain["restore"]:
                         omit_chains.append(chain_id)
-            try:
-                store_midi_learn = zs3_id == "zs3-0" or zs3["store_midi_learn"]
-            except:
-                store_midi_learn = False
+            restore_midi_learn = zs3.get("restore_midi_learn", None)
 
         # Initialise zs3
         self.zs3[zs3_id] = {
             "title": title,
             "active_chain": self.chain_manager.active_chain.chain_id,
-            "global": {}
+            "global": {},
+            "restore_midi_learn": restore_midi_learn
         }
-        if store_midi_learn:
-            self.zs3[zs3_id]["store_midi_learn"] = True
+
         chain_states = {}
         for chain_id, chain in self.chain_manager.chains.items():
             chain_state = {
@@ -1663,13 +1666,12 @@ class zynthian_state_manager:
                             break
                 chain_state["audio_out"].append(out)
             # Add chain MIDI mapping
-            if store_midi_learn:
-                for key, zctrls in self.chain_manager.chain_midi_cc_binding.items():
-                    if chain_id == (key >> 16) & 0xff:
-                        key_low = key & 0xff7f
-                        chain_state["midi_learn"][key_low] = []
-                        for zctrl in zctrls:
-                            chain_state["midi_learn"][key_low].append([zctrl.processor.id, zctrl.symbol])
+            for key, zctrls in self.chain_manager.chain_midi_cc_binding.items():
+                if chain_id == (key >> 16) & 0xff:
+                    key_low = key & 0xff7f
+                    chain_state["midi_learn"][key_low] = []
+                    for zctrl in zctrls:
+                        chain_state["midi_learn"][key_low].append([zctrl.processor.id, zctrl.symbol])
             if chain_state:
                 chain_states[chain_id] = chain_state
         if chain_states:
@@ -1696,10 +1698,9 @@ class zynthian_state_manager:
             self.zs3[zs3_id]["processors"] = processor_states
 
         # Add MIDI capture state
-        if store_midi_learn:
-            mcstate = self.get_midi_capture_state()
-            if mcstate:
-                self.zs3[zs3_id]["midi_capture"] = mcstate
+        mcstate = self.get_midi_capture_state()
+        if mcstate:
+            self.zs3[zs3_id]["midi_capture"] = mcstate
 
         # Add global parameters
         self.zs3[zs3_id]["global"]["clock_source"] = zynautoconnect.get_ext_clock_device_name()
@@ -1980,10 +1981,11 @@ class zynthian_state_manager:
 
         return mcstate
 
-    def set_midi_capture_state(self, mcstate=None):
-        """Set midi input (capture) state: flags, chain routing, etc.
-
-        mcstate : dictionary with state. None for reset state to defaults.
+    def set_midi_capture_state(self, mcstate=None, restore_midi_learn=True):
+        """ Set midi input (capture) state: flags, chain routing, etc.
+        Args:
+            mcstate : dictionary with state. None for reset state to defaults.
+            restore_midi_learn: True to restore absolute MIDI CC binding
         """
         if mcstate:
             ctrldev_state_drivers = {}
@@ -2035,29 +2037,30 @@ class zynthian_state_manager:
                     izmip = 0xff
 
                 # Absolute MIDI-learn state
-                try:
-                    midi_learn_state = state["midi_learn"]
-                except:
+                if restore_midi_learn:
                     try:
-                        midi_learn_state = state["midi_cc"]
+                        midi_learn_state = state["midi_learn"]
                     except:
-                        midi_learn_state = None
-                if midi_learn_state:
-                    for key_low, cfg in midi_learn_state.items():
-                        key_low = int(key_low)
-                        for proc_id, symbol in cfg:
-                            try:
-                                processor = self.chain_manager.processors[proc_id]
-                            except:
-                                continue
-                            try:
-                                zctrl = processor.controllers_dict[symbol]
-                            except:
-                                logging.warning(f"Can't MIDI learn '{symbol}'. Controller not found in processor {proc_id}.")
-                                continue
-                            chan = (key_low >> 8) & 0xff
-                            cc = key_low & 0x7f
-                            self.chain_manager.add_midi_learn(chan, cc, zctrl, izmip)
+                        try:
+                            midi_learn_state = state["midi_cc"]
+                        except:
+                            midi_learn_state = None
+                    if midi_learn_state:
+                        for key_low, cfg in midi_learn_state.items():
+                            key_low = int(key_low)
+                            for proc_id, symbol in cfg:
+                                try:
+                                    processor = self.chain_manager.processors[proc_id]
+                                except:
+                                    continue
+                                try:
+                                    zctrl = processor.controllers_dict[symbol]
+                                except:
+                                    logging.warning(f"Can't MIDI learn '{symbol}'. Controller not found in processor {proc_id}.")
+                                    continue
+                                chan = (key_low >> 8) & 0xff
+                                cc = key_low & 0x7f
+                                self.chain_manager.add_midi_learn(chan, cc, zctrl, izmip)
             self.ctrldev_manager.set_state_drivers(ctrldev_state_drivers)
 
         else:

--- a/zyngine/zynthian_state_manager.py
+++ b/zyngine/zynthian_state_manager.py
@@ -1349,6 +1349,14 @@ class zynthian_state_manager:
         except:
             tstate["restore"] = False
 
+    def toggle_zs3_store_midi_learn(self, zs3_id):
+        if zs3_id == "zs3-0" or zs3_id not in self.zs3:
+            return
+        try:
+            self.zs3[zs3_id].pop("store_midi_learn")
+        except:
+            self.zs3[zs3_id]["store_midi_learn"] = True
+
     def load_zs3(self, zs3_id, autoconnect=True):
         """Restore a ZS3
 
@@ -1437,10 +1445,15 @@ class zynthian_state_manager:
                             chain.audio_out.append(out)
                 chain.rebuild_graph()
 
-                # Current (right) chain MIDI-learn state
+                # Restore CC binding if configured, else use default from zs3-0
+                if "midi_learn" in chain_state or "midi_cc" in chain.state:
+                    ml_chain_state = chain_state
+                else:
+                    ml_chain_state = self.zs3["zs3-0"]
+                # Current (correct) chain MIDI-learn state
                 self.chain_manager.clean_midi_learn(chain_id)
-                if "midi_learn" in chain_state:
-                    for low_key, cfg in chain_state["midi_learn"].items():
+                if "midi_learn" in ml_chain_state:
+                    for low_key, cfg in ml_chain_state["midi_learn"].items():
                         low_key = int(low_key)
                         midi_chan = (low_key >> 8) & 0xff
                         midi_cc = low_key & 0x7f
@@ -1448,8 +1461,8 @@ class zynthian_state_manager:
                             if proc_id in self.chain_manager.processors:
                                 restored_cc_mapping.append((proc_id, symbol, midi_chan, midi_cc))
                 # Legacy (wrong) chain MIDI-learn state
-                elif "midi_cc" in chain_state:
-                    for midi_cc, cfg in chain_state["midi_cc"].items():
+                elif "midi_cc" in ml_chain_state:
+                    for midi_cc, cfg in ml_chain_state["midi_cc"].items():
                         midi_chan = 0xff
                         midi_cc = int(midi_cc) & 0x7f
                         for proc_id, symbol in cfg:
@@ -1601,6 +1614,10 @@ class zynthian_state_manager:
                 for chain_id, chain in zs3["chains"].items():
                     if "restore" in chain and not chain["restore"]:
                         omit_chains.append(chain_id)
+            try:
+                store_midi_learn = zs3_id == "zs3-0" or zs3["store_midi_learn"]
+            except:
+                store_midi_learn = False
 
         # Initialise zs3
         self.zs3[zs3_id] = {
@@ -1608,6 +1625,8 @@ class zynthian_state_manager:
             "active_chain": self.chain_manager.active_chain.chain_id,
             "global": {}
         }
+        if store_midi_learn:
+            self.zs3[zs3_id]["store_midi_learn"] = True
         chain_states = {}
         for chain_id, chain in self.chain_manager.chains.items():
             chain_state = {
@@ -1644,12 +1663,13 @@ class zynthian_state_manager:
                             break
                 chain_state["audio_out"].append(out)
             # Add chain MIDI mapping
-            for key, zctrls in self.chain_manager.chain_midi_cc_binding.items():
-                if chain_id == (key >> 16) & 0xff:
-                    key_low = key & 0xff7f
-                    chain_state["midi_learn"][key_low] = []
-                    for zctrl in zctrls:
-                        chain_state["midi_learn"][key_low].append([zctrl.processor.id, zctrl.symbol])
+            if store_midi_learn:
+                for key, zctrls in self.chain_manager.chain_midi_cc_binding.items():
+                    if chain_id == (key >> 16) & 0xff:
+                        key_low = key & 0xff7f
+                        chain_state["midi_learn"][key_low] = []
+                        for zctrl in zctrls:
+                            chain_state["midi_learn"][key_low].append([zctrl.processor.id, zctrl.symbol])
             if chain_state:
                 chain_states[chain_id] = chain_state
         if chain_states:
@@ -1676,9 +1696,10 @@ class zynthian_state_manager:
             self.zs3[zs3_id]["processors"] = processor_states
 
         # Add MIDI capture state
-        mcstate = self.get_midi_capture_state()
-        if mcstate:
-            self.zs3[zs3_id]["midi_capture"] = mcstate
+        if store_midi_learn:
+            mcstate = self.get_midi_capture_state()
+            if mcstate:
+                self.zs3[zs3_id]["midi_capture"] = mcstate
 
         # Add global parameters
         self.zs3[zs3_id]["global"]["clock_source"] = zynautoconnect.get_ext_clock_device_name()

--- a/zyngine/zynthian_state_manager.py
+++ b/zyngine/zynthian_state_manager.py
@@ -1341,14 +1341,7 @@ class zynthian_state_manager:
     def toggle_zs3_restore_flag(self, zs3_id, type, id=None):
         zs3_state = self.zs3[zs3_id]
         if type == "midi_learn":
-            val = zs3_state.get("restore_midi_learn", None)
-            if val == None:
-                val = True
-            elif val == True:
-                val = False
-            else:
-                val = None
-            zs3_state["restore_midi_learn"] = val
+            zs3_state["restore_midi_learn"] = not zs3_state.get("restore_midi_learn", False)
             return
         try:
             tstate = zs3_state[type][int(id)]
@@ -1391,7 +1384,7 @@ class zynthian_state_manager:
 
         restored_chains = []
         restored_cc_mapping = []
-        restore_midi_learn = zs3_state.get("restore_midi_learn", None)
+        restore_midi_learn = zs3_id == "zs3-0" or zs3_state.get("restore_midi_learn", False)
         mute_pause = False
         if "chains" in zs3_state:
             self.set_busy_details("restoring chains state")
@@ -1449,16 +1442,11 @@ class zynthian_state_manager:
                             chain.audio_out.append(out)
                 chain.rebuild_graph()
 
-                ml_chain_state = None
                 if restore_midi_learn:
-                    ml_chain_state = chain_state
-                elif restore_midi_learn is None and chain_id in self.zs3["zs3-0"]["chains"]:
-                    ml_chain_state = self.zs3["zs3-0"]["chains"][chain_id]
-                if ml_chain_state:
                     # Current (correct) chain MIDI-learn state
                     self.chain_manager.clean_midi_learn(chain_id)
-                    if "midi_learn" in ml_chain_state:
-                        for low_key, cfg in ml_chain_state["midi_learn"].items():
+                    if "midi_learn" in chain_state:
+                        for low_key, cfg in chain_state["midi_learn"].items():
                             low_key = int(low_key)
                             midi_chan = (low_key >> 8) & 0xff
                             midi_cc = low_key & 0x7f
@@ -1466,8 +1454,8 @@ class zynthian_state_manager:
                                 if proc_id in self.chain_manager.processors:
                                     restored_cc_mapping.append((proc_id, symbol, midi_chan, midi_cc))
                     # Legacy (wrong) chain MIDI-learn state
-                    elif "midi_cc" in ml_chain_state:
-                        for midi_cc, cfg in ml_chain_state["midi_cc"].items():
+                    elif "midi_cc" in chain_state:
+                        for midi_cc, cfg in chain_state["midi_cc"].items():
                             midi_chan = 0xff
                             midi_cc = int(midi_cc) & 0x7f
                             for proc_id, symbol in cfg:
@@ -1510,7 +1498,7 @@ class zynthian_state_manager:
 
         if "midi_capture" in zs3_state:
             self.set_busy_details("restoring midi capture state")
-            self.set_midi_capture_state(zs3_state['midi_capture'], restore_midi_learn=restore_midi_learn!=False)
+            self.set_midi_capture_state(zs3_state['midi_capture'], restore_midi_learn=restore_midi_learn)
 
         if "global" in zs3_state:
             try:
@@ -1609,7 +1597,7 @@ class zynthian_state_manager:
         # Store persistent config
         omit_processors = []
         omit_chains = []
-        restore_midi_learn = None
+        restore_midi_learn = False
         if zs3_id in self.zs3:
             zs3 = self.zs3[zs3_id]
             if "processors" in zs3:
@@ -1620,15 +1608,16 @@ class zynthian_state_manager:
                 for chain_id, chain in zs3["chains"].items():
                     if "restore" in chain and not chain["restore"]:
                         omit_chains.append(chain_id)
-            restore_midi_learn = zs3.get("restore_midi_learn", None)
+            restore_midi_learn = zs3.get("restore_midi_learn", False)
 
         # Initialise zs3
         self.zs3[zs3_id] = {
             "title": title,
             "active_chain": self.chain_manager.active_chain.chain_id,
-            "global": {},
-            "restore_midi_learn": restore_midi_learn
+            "global": {}
         }
+        if restore_midi_learn:
+            self.zs3[zs3_id]["restore_midi_learn"] = True
 
         chain_states = {}
         for chain_id, chain in self.chain_manager.chains.items():

--- a/zyngui/zynthian_gui_zs3_options.py
+++ b/zyngui/zynthian_gui_zs3_options.py
@@ -155,12 +155,18 @@ class zynthian_gui_zs3_options(zynthian_gui_selector_info):
                     else:
                         options[f"\u2610   ⤷{label}"] = [f"processors_{proc.id}", [info, None]]
         options["Toggle All Mixer"][0] = ",".join(mixer_list)
-        options["Store"] = None
-        store_midi_learn = "store_midi_learn" in state
-        if store_midi_learn:
-            options[f"\u2612 MIDI Learn"] = [f"store_midi_learn", store_midi_learn]
+        try:
+            restore_midi_learn = state["restore_midi_learn"]
+        except:
+            restore_midi_learn = None
+        params = ["midi_learn", ["Toggle how MIDI learn (CC binding) is restored.", None]]
+        if restore_midi_learn is None:
+            options["Do not restore MIDI learn"] = params
+        elif restore_midi_learn:
+            options["Restore MIDI learn from this ZS3"] = params
         else:
-            options[f"\u2610 MIDI Learn"] = [f"store_midi_learn", store_midi_learn]
+            options["Restore MIDI learn from default ZS3"] = params
+
         return options
 
     def zs3_restoring_options_select_cb(self, label, param, ct):
@@ -169,8 +175,8 @@ class zynthian_gui_zs3_options(zynthian_gui_selector_info):
             for id in ids:
                 self.zyngui.state_manager.toggle_zs3_restore_flag(self.zs3_id, "processors", id)
             return
-        elif param == "store_midi_learn":
-            self.zyngui.state_manager.toggle_zs3_store_midi_learn(self.zs3_id)
+        elif param == "midi_learn":
+            self.zyngui.state_manager.toggle_zs3_restore_flag(self.zs3_id, "midi_learn")
             return
         type, id = param.split("_")
         if ct == "S":

--- a/zyngui/zynthian_gui_zs3_options.py
+++ b/zyngui/zynthian_gui_zs3_options.py
@@ -155,17 +155,8 @@ class zynthian_gui_zs3_options(zynthian_gui_selector_info):
                     else:
                         options[f"\u2610   ⤷{label}"] = [f"processors_{proc.id}", [info, None]]
         options["Toggle All Mixer"][0] = ",".join(mixer_list)
-        try:
-            restore_midi_learn = state["restore_midi_learn"]
-        except:
-            restore_midi_learn = None
-        params = ["midi_learn", ["Toggle how MIDI learn (CC binding) is restored.", None]]
-        if restore_midi_learn is None:
-            options["Do not restore MIDI learn"] = params
-        elif restore_midi_learn:
-            options["Restore MIDI learn from this ZS3"] = params
-        else:
-            options["Restore MIDI learn from default ZS3"] = params
+        prefix = "\u2612" if state.get("restore_midi_learn", False) else "\u2610"
+        options[f"{prefix} MIDI learn"] = ["midi_learn", ["Toggle whether MIDI learn (CC binding) is restored.", None]]
 
         return options
 

--- a/zyngui/zynthian_gui_zs3_options.py
+++ b/zyngui/zynthian_gui_zs3_options.py
@@ -155,6 +155,12 @@ class zynthian_gui_zs3_options(zynthian_gui_selector_info):
                     else:
                         options[f"\u2610   ⤷{label}"] = [f"processors_{proc.id}", [info, None]]
         options["Toggle All Mixer"][0] = ",".join(mixer_list)
+        options["Store"] = None
+        store_midi_learn = "store_midi_learn" in state
+        if store_midi_learn:
+            options[f"\u2612 MIDI Learn"] = [f"store_midi_learn", store_midi_learn]
+        else:
+            options[f"\u2610 MIDI Learn"] = [f"store_midi_learn", store_midi_learn]
         return options
 
     def zs3_restoring_options_select_cb(self, label, param, ct):
@@ -162,6 +168,9 @@ class zynthian_gui_zs3_options(zynthian_gui_selector_info):
             ids = param.split(",")
             for id in ids:
                 self.zyngui.state_manager.toggle_zs3_restore_flag(self.zs3_id, "processors", id)
+            return
+        elif param == "store_midi_learn":
+            self.zyngui.state_manager.toggle_zs3_store_midi_learn(self.zs3_id)
             return
         type, id = param.split("_")
         if ct == "S":

--- a/zynthian_state_schema.py
+++ b/zynthian_state_schema.py
@@ -70,7 +70,7 @@ ZynthianState = {
         "zs3-0": {  # ZS3 state when snapshot saved
             "title": "Last state",  # ZS3 title
             "active_chain": "1", # Optional active chain id (overides base value)
-            "store_midi_learn": True, # Optional store midi CC binding for this zs3 (Default: False)
+            "restore_midi_learn": None, # Optional restore midi CC binding for this zs3 [True|False|None] (Default: None to restore from ZS3-0)
             "processors": {  # Dictionary of processor settings
                 "1": {  # Processor id:1
                     "restore": True, # Optional False to omit from processor parameters from restore (Default: True)

--- a/zynthian_state_schema.py
+++ b/zynthian_state_schema.py
@@ -70,6 +70,7 @@ ZynthianState = {
         "zs3-0": {  # ZS3 state when snapshot saved
             "title": "Last state",  # ZS3 title
             "active_chain": "1", # Optional active chain id (overides base value)
+            "store_midi_learn": True, # Optional store midi CC binding for this zs3 (Default: False)
             "processors": {  # Dictionary of processor settings
                 "1": {  # Processor id:1
                     "restore": True, # Optional False to omit from processor parameters from restore (Default: True)

--- a/zynthian_state_schema.py
+++ b/zynthian_state_schema.py
@@ -70,7 +70,7 @@ ZynthianState = {
         "zs3-0": {  # ZS3 state when snapshot saved
             "title": "Last state",  # ZS3 title
             "active_chain": "1", # Optional active chain id (overides base value)
-            "restore_midi_learn": None, # Optional restore midi CC binding for this zs3 [True|False|None] (Default: None to restore from ZS3-0)
+            "restore_midi_learn": False, # Optional restore midi CC binding (Default: False)
             "processors": {  # Dictionary of processor settings
                 "1": {  # Processor id:1
                     "restore": True, # Optional False to omit from processor parameters from restore (Default: True)


### PR DESCRIPTION
Adds option to each ZS3 to enable recall of learned MIDI CC binding. Default is disabled. If enabled in all ZS3 it provides the same functionality as before. If disabled in all ZS3 then there is a consistent MIDI learn across all ZS3 which is probably the most desirable workflow and the purpose of this change.