### PR TITLE
APCKey25: Return True on MIDI CC Events

### DIFF
--- a/zyngine/ctrldev/zynthian_ctrldev_akai_apc_key25_mk2.py
+++ b/zyngine/ctrldev/zynthian_ctrldev_akai_apc_key25_mk2.py
@@ -491,7 +491,7 @@ class DeviceHandler(ModeHandlerBase):
     def cc_change(self, ccnum, ccval):
         delta = self._knobs_ease.feed(ccnum, ccval, self._is_shifted)
         if delta is None:
-            return
+            return True
 
         zynpot = {
             KNOB_LAYER: 0,
@@ -499,10 +499,12 @@ class DeviceHandler(ModeHandlerBase):
             KNOB_SNAPSHOT: 2,
             KNOB_SELECT: 3
         }.get(ccnum, None)
+
         if zynpot is None:
-            return
+            return True
 
         self._state_manager.send_cuia("ZYNPOT", [zynpot, delta])
+        return True
 
     def on_alt_mode(self, alt_mode, refresh=False):
         if refresh:
@@ -777,14 +779,14 @@ class MixerHandler(ModeHandlerBase):
         if self._is_shifted:
             # Only main chain is handled with SHIFT, ignore the rest
             if ccnum != self.main_chain_knob:
-                return False
+                return True
             else:
                 index = -1
         else:
             index = (ccnum - KNOB_1) + self.driver.scroll_h
             chain = self._chain_manager.get_chain_by_index(index)
             if chain is None or chain.chain_id == 0:
-                return False
+                return True
             #mixer_chan = chain.mixer_chan
 
         if type == "level" or type == "balance":
@@ -2097,7 +2099,7 @@ class StepSeqHandler(ModeHandlerBase):
     def cc_change(self, ccnum, ccval):
         delta = self._knobs_ease.feed(ccnum, ccval, self._is_shifted)
         if delta is None:
-            return
+            return True
 
         if self._pressed_pads:
             if self._note_config is not None:
@@ -2137,6 +2139,7 @@ class StepSeqHandler(ModeHandlerBase):
         if ccnum == KNOB_1:
             delta *= 0.1 if self._is_shifted else 1
             self._zynseq.set_tempo(self._zynseq.get_tempo() + delta)
+            return True
 
         # Update sequence's chain volume
         elif ccnum == KNOB_2:
@@ -2149,7 +2152,8 @@ class StepSeqHandler(ModeHandlerBase):
                 level = max(
                     0, min(100, value * 100 + delta))
                 zctrl.set_value(level / 100)
-                
+            return True
+
     def update_seq_state(self, phrase, chan, state=None, mode=None, group=None):
         self._is_playing = state != zynseq.SEQ_STOPPED
         if state == zynseq.SEQ_STOPPED and self._cursor < self._used_pads:
@@ -2894,6 +2898,7 @@ class zynthian_ctrldev_akai_apc_key25_mk2(zynthian_ctrldev_zynmixer, zynthian_ct
     dev_ids = ["APC Key 25 mk2 MIDI 2", "APC Key 25 mk2 IN 2"]
     driver_name = 'AKAI APC Key25 MK2'
     driver_description = 'Full UI integration'
+    unroute_from_chains = 0b1111111111111111
     apc_color_variant = "apc"
     cols = 8
     rows = 5

--- a/zyngine/ctrldev/zynthian_ctrldev_akai_apc_key25_mk2_sooperlooper.py
+++ b/zyngine/ctrldev/zynthian_ctrldev_akai_apc_key25_mk2_sooperlooper.py
@@ -1003,25 +1003,25 @@ class looper_handler(
             ccnum, ccval, getDeviceSetting("shifted", self.state)
         )  # @todo: use self._is_shifted (or not at all?)
         if delta is None:
-            return
+            return True
         knobnum = ccnum - 48
         if doLevelsOfSelectedMode(self.state):
             if knobnum == 0:
-                return
+                return True
             level = TRACK_LEVELS[knobnum]
             if not level:
-                return
+                return True
             loopnum = getGlob("selected_loop_num", self.state)
             if loopnum == -1:
-                return
+                return True
             self.increase(delta, level, self.state["tracks"][loopnum], loopnum)
-            return
+            return True
         loopoffset = getLoopoffset(self.state)
         loopnum = (knobnum % KNOBS_PER_ROW) - (loopoffset - 1)
         tracks = self.state["tracks"]
         track = tracks.get(loopnum)
         if track is None:  # Check if track is None
-            return None  # Or handle as needed
+            return True  # Or handle as needed
         funnum = knobnum // KNOBS_PER_ROW
         # todo: this could be larger than 1?
         funs = ["wet", "pan"]
@@ -1049,7 +1049,7 @@ class looper_handler(
                         self.increase(delta, ctrl, track, loopnum)
         else:
             self.increase(delta, fun, track, loopnum)
-        pass
+        return True
 
     def pad_event(self, evtype, pad):
         submode = getDeviceSetting("submode", self.state)

--- a/zyngine/ctrldev/zynthian_ctrldev_akai_apc_key25_sooperlooper.py
+++ b/zyngine/ctrldev/zynthian_ctrldev_akai_apc_key25_sooperlooper.py
@@ -307,21 +307,21 @@ class zynthian_ctrldev_akai_apc_key25_sooperlooper(zynthian_ctrldev_akai_apc_key
             if self._current_handler == self._levels2_handler:
             # if doLevelsOfSelectedMode(self.state):
                 if knobnum == 0:
-                    return
+                    return True
                 level = TRACK_LEVELS[knobnum]
                 if not level:
-                    return
+                    return True
                 loopnum = getGlob("selected_loop_num", self.state)
                 if loopnum == -1:
-                    return
+                    return True
                 self.set(ccval, level, self.state["tracks"][loopnum], loopnum)
-                return
+                return True
             loopoffset = getLoopoffset(self.state)
             loopnum = (knobnum % KNOBS_PER_ROW) - (loopoffset - 1)
             tracks = self.state["tracks"]
             track = tracks.get(loopnum)
             if track is None:  # Check if track is None
-                return None  # Or handle as needed
+                return True  # Or handle as needed
             funnum = knobnum // KNOBS_PER_ROW
             # todo: this could be larger than 1?
             funs = ["wet", "pan"]
@@ -346,6 +346,4 @@ class zynthian_ctrldev_akai_apc_key25_sooperlooper(zynthian_ctrldev_akai_apc_key
                             self.set(ccval, ctrl, track, loopnum)
             else:
                 self.set(ccval, fun, track, loopnum)
-
-
-
+            return True


### PR DESCRIPTION
There might be a use case for returning False, and letting the Zynthian router take care of the unused CCs (for MIDI learn etc), but this would be undocumented behaviour for these drivers, and letting some arbitrary knobs in arbitrary situations do this is very confusing.

See https://discourse.zynthian.org/t/new-control-device-manager-controller-device-drivers/8593/270