### PR TITLE
multitouch: add 90/270 axis-swap rotation via DISPLAY_ROTATION

### DIFF
--- a/zyngui/multitouch.py
+++ b/zyngui/multitouch.py
@@ -182,7 +182,47 @@ class MultiTouch(object):
     EVENT_FORMAT = str('llHHi')
     EVENT_SIZE = struct.calcsize(EVENT_FORMAT)
 
-    def __init__(self, state_manager, invert_x_axis=False, invert_y_axis=False):
+    # Map a DISPLAY_ROTATION value to (swap_xy, invert_x, invert_y).
+    #   None     -> 0 deg   (native portrait)
+    #   Right    -> 90 deg  (landscape; verified on RPi Touch Display 2)
+    #   Inverted -> 180 deg (previous behaviour, unchanged)
+    #   Left     -> 270 deg (mathematical mirror of Right; not hw-verified)
+    ROTATION_MAP = {
+        'None':     (False, False, False),
+        'Right':    (True,  False, True),
+        'Inverted': (False, True,  True),
+        'Left':     (True,  True,  False),
+    }
+
+    @staticmethod
+    def _transform_abs(is_x_event, value, swap_xy, invert_x, invert_y, max_x, max_y):
+        """Map a raw ABS_MT_POSITION_{X,Y} event to a (dest_attr, value) pair.
+
+        is_x_event - True for a raw panel-X event, False for a raw panel-Y event.
+        value      - the raw event value.
+        Returns ("x_root" | "y_root", transformed_value).
+
+        When swap_xy is False: raw X -> x_root, raw Y -> y_root (legacy).
+        When swap_xy is True:  raw X -> y_root, raw Y -> x_root (90/270 deg).
+        The invert flag is chosen by the *destination* axis; the maximum used
+        for inversion is the *source* axis maximum (max_x for a raw-X event,
+        max_y for a raw-Y event).
+        """
+        if is_x_event:
+            src_max = max_x
+            if swap_xy:
+                dest, invert = "y_root", invert_y
+            else:
+                dest, invert = "x_root", invert_x
+        else:
+            src_max = max_y
+            if swap_xy:
+                dest, invert = "x_root", invert_x
+            else:
+                dest, invert = "y_root", invert_y
+        return dest, (src_max - value if invert else value)
+
+    def __init__(self, state_manager, invert_x_axis=False, invert_y_axis=False, swap_xy=False):
         """Instantiate the touch driver
 
         Creates an instance of the driver attached to the first multitouch hardware discovered.
@@ -190,6 +230,11 @@ class MultiTouch(object):
         state_manager - State Manager object used for disabling powersave mode
         invert_x_axis - True to invert x axis (optional)
         invert_y_axis - True to invert y axis (optional)
+        swap_xy - True to swap the X and Y axes, e.g. for a portrait-native
+                  panel mounted in landscape (90/270 deg). When swapped, the
+                  invert flags refer to the *destination* (screen) axis, while
+                  each inversion uses its *source* (panel) axis maximum.
+                  (optional)
         """
 
         self.state_manager = state_manager
@@ -197,6 +242,7 @@ class MultiTouch(object):
         self.thread = None  # Background thread processing touch events
         self._invert_x = invert_x_axis
         self._invert_y = invert_y_axis
+        self._swap_xy = swap_xy
         self.events = []  # List of pending multipoint events (not yet sent)
         self.gesture_events = []  # List of events currently active as gestures
         self._g_pending = None  # Event that is pending multiple touch gesture start
@@ -315,17 +361,17 @@ class MultiTouch(object):
                     if self._current_touch not in self.events:
                         self.events.append(self._current_touch)
                 elif evdev_event.code == ecodes.ABS_MT_POSITION_X:
-                    if self._invert_x:
-                        self._current_touch.x_root = self.max_x - evdev_event.value
-                    else:
-                        self._current_touch.x_root = evdev_event.value
+                    dest, val = self._transform_abs(
+                        True, evdev_event.value, self._swap_xy,
+                        self._invert_x, self._invert_y, self.max_x, self.max_y)
+                    setattr(self._current_touch, dest, val)
                     if self._current_touch not in self.events:
                         self.events.append(self._current_touch)
                 elif evdev_event.code == ecodes.ABS_MT_POSITION_Y:
-                    if self._invert_y:
-                        self._current_touch.y_root = self.max_y - evdev_event.value
-                    else:
-                        self._current_touch.y_root = evdev_event.value
+                    dest, val = self._transform_abs(
+                        False, evdev_event.value, self._swap_xy,
+                        self._invert_x, self._invert_y, self.max_x, self.max_y)
+                    setattr(self._current_touch, dest, val)
                     if self._current_touch not in self.events:
                         self.events.append(self._current_touch)
 

--- a/zyngui/multitouch_rotation_test.py
+++ b/zyngui/multitouch_rotation_test.py
@@ -1,0 +1,149 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# ******************************************************************************
+# ZYNTHIAN PROJECT: Zynthian GUI
+#
+# Unit tests for MultiTouch coordinate rotation (90/270 deg touch support)
+#
+# ******************************************************************************
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of
+# the License, or any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# For a full copy of the GNU General Public License see the LICENSE.txt file.
+#
+# ******************************************************************************
+"""Tests for MultiTouch.ROTATION_MAP and MultiTouch._transform_abs.
+
+Runs standalone (``python3 zyngui/multitouch_rotation_test.py``) or under
+pytest. multitouch.py imports tkinter / tkinterweb / evdev / zynthian_gui_config
+at module load, so those are stubbed below to import the class with neither a
+GUI, a display, nor touch hardware present.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+# Make the repo root importable regardless of the current working directory.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+# Stub the heavy / hardware-bound deps pulled in at multitouch import time.
+for _name in ("tkinter", "tkinterweb", "evdev"):
+    sys.modules.setdefault(_name, MagicMock())
+sys.modules.setdefault("zyngui.zynthian_gui_config", MagicMock())
+
+from zyngui.multitouch import MultiTouch  # noqa: E402
+
+# Reference panel: RPi Touch Display 2, native (unswapped) evdev ranges.
+MAX_X, MAX_Y = 719, 1279
+# Landscape screen after X11 Rotate "right": 1280 wide x 720 tall.
+WIDTH, HEIGHT = MAX_Y + 1, MAX_X + 1
+
+# Labeled corner touches captured with evtest on the reference unit, as raw
+# panel (X, Y). These are the empirical oracle for the "Right" mapping.
+CORNERS = {
+    "top-left":     (704, 39),
+    "top-right":    (649, 1218),
+    "bottom-left":  (47, 98),
+    "bottom-right": (67, 1197),
+}
+
+
+def map_xy(rotation, raw_x, raw_y, max_x=MAX_X, max_y=MAX_Y):
+    """Full raw-panel -> screen mapping via the shipped map + transform.
+
+    Feeds a raw X event and a raw Y event through MultiTouch._transform_abs
+    exactly as the event loop does, then assembles (x_root, y_root).
+    """
+    swap, ix, iy = MultiTouch.ROTATION_MAP[rotation]
+    dest_a, val_a = MultiTouch._transform_abs(
+        True, raw_x, swap, ix, iy, max_x, max_y)
+    dest_b, val_b = MultiTouch._transform_abs(
+        False, raw_y, swap, ix, iy, max_x, max_y)
+    coords = {dest_a: val_a, dest_b: val_b}
+    return coords["x_root"], coords["y_root"]
+
+
+def test_rotation_map_keys_and_legacy_values():
+    # Exactly the four supported rotations, no more.
+    assert set(MultiTouch.ROTATION_MAP) == {"None", "Right", "Inverted", "Left"}
+    # Legacy behaviour must not drift:
+    assert MultiTouch.ROTATION_MAP["None"] == (False, False, False)
+    assert MultiTouch.ROTATION_MAP["Inverted"] == (False, True, True)
+
+
+def test_none_is_identity():
+    for raw_x, raw_y in CORNERS.values():
+        assert map_xy("None", raw_x, raw_y) == (raw_x, raw_y)
+
+
+def test_inverted_flips_both_axes():
+    # Regression lock for the previous Inverted behaviour (invert both, no swap).
+    for raw_x, raw_y in CORNERS.values():
+        assert map_xy("Inverted", raw_x, raw_y) == (MAX_X - raw_x, MAX_Y - raw_y)
+
+
+# --- Right: verified against hardware corner data ----------------------------
+
+EXPECTED_RIGHT = {
+    "top-left":     (39, 15),     # left,  top
+    "top-right":    (1218, 70),   # right, top
+    "bottom-left":  (98, 672),    # left,  bottom
+    "bottom-right": (1197, 652),  # right, bottom
+}
+
+
+def test_right_exact_mapping():
+    for name, (raw_x, raw_y) in CORNERS.items():
+        assert map_xy("Right", raw_x, raw_y) == EXPECTED_RIGHT[name], name
+
+
+def test_right_corners_land_in_correct_quadrant():
+    # The "not mirrored" check: each labeled corner falls in its own quadrant.
+    quadrant = {
+        "top-left":     (lambda x: x < WIDTH / 2,  lambda y: y < HEIGHT / 2),
+        "top-right":    (lambda x: x > WIDTH / 2,  lambda y: y < HEIGHT / 2),
+        "bottom-left":  (lambda x: x < WIDTH / 2,  lambda y: y > HEIGHT / 2),
+        "bottom-right": (lambda x: x > WIDTH / 2,  lambda y: y > HEIGHT / 2),
+    }
+    for name, (raw_x, raw_y) in CORNERS.items():
+        sx, sy = map_xy("Right", raw_x, raw_y)
+        chk_x, chk_y = quadrant[name]
+        assert chk_x(sx) and chk_y(sy), f"{name} landed at ({sx},{sy})"
+
+
+# --- Left: NOT hardware-verified; checked as the 180-deg mirror of Right -----
+
+def test_left_is_180deg_mirror_of_right():
+    # 270 deg must equal 90 deg with both screen axes flipped. Self-consistency
+    # only: the Left mapping has not been confirmed on hardware.
+    for raw_x, raw_y in CORNERS.values():
+        rx, ry = map_xy("Right", raw_x, raw_y)
+        lx, ly = map_xy("Left", raw_x, raw_y)
+        assert (lx, ly) == (WIDTH - 1 - rx, HEIGHT - 1 - ry)
+
+
+if __name__ == "__main__":
+    _tests = [v for k, v in sorted(globals().items())
+              if k.startswith("test_") and callable(v)]
+    _failed = 0
+    for _t in _tests:
+        try:
+            _t()
+            print("PASS  %s" % _t.__name__)
+        except AssertionError as e:
+            _failed += 1
+            print("FAIL  %s: %s" % (_t.__name__, e))
+    print("\n%d/%d passed" % (len(_tests) - _failed, len(_tests)))
+    sys.exit(1 if _failed else 0)

--- a/zyngui/zynthian_gui.py
+++ b/zyngui/zynthian_gui.py
@@ -189,10 +189,15 @@ class zynthian_gui:
 
         # Init multitouch driver
         #if zynthian_gui_config.check_kit_version(["V5"]) or
-        if os.environ.get('DISPLAY_ROTATION', 'None') == 'Inverted':
-            self.multitouch = MultiTouch(self.state_manager, invert_x_axis=True, invert_y_axis=True)
-        else:
-            self.multitouch = MultiTouch(self.state_manager)
+        # DISPLAY_ROTATION is a touch-rotation hint (webconf field "Touch
+        # Rotation"). MultiTouch.ROTATION_MAP turns it into the driver's
+        # (swap_xy, invert_x, invert_y) flags; unknown values fall back to
+        # "None" (native, no transform), preserving previous behaviour.
+        _swap, _ix, _iy = MultiTouch.ROTATION_MAP.get(
+            os.environ.get('DISPLAY_ROTATION', 'None'),
+            MultiTouch.ROTATION_MAP['None'])
+        self.multitouch = MultiTouch(self.state_manager, invert_x_axis=_ix,
+                                     invert_y_axis=_iy, swap_xy=_swap)
 
         # Load keyboard binding map
         zynthian_gui_keybinding.load()


### PR DESCRIPTION
# multitouch: add 90°/270° axis-swap rotation via `DISPLAY_ROTATION`

**Base:** `zynthian/zynthian-ui:vangelis`
**Scope:** zynthian-ui only. Additive; no change to existing `None` / `Inverted` behaviour.
**Companion:** a follow-up webconf + zynthian-sys PR (PR 2) adds a Raspberry Pi Touch Display 2 (7″) display definition and exposes the new rotations in the UI. This PR is usable on its own (see "Note on UI exposure" below).

## Problem

`zyngui/multitouch.py` reads the touch evdev device directly and disables the X-layer xinput device, so every X11 / libinput / evdev coordinate transform is bypassed. The driver maps `ABS_MT_POSITION_X → x_root` and `ABS_MT_POSITION_Y → y_root`, with only `invert_x` / `invert_y` available — **there is no axis swap.** A portrait-native DSI panel run in landscape (90° or 270°) therefore has no working touch path: the picture rotates under X, but touch does not follow.

This was hit in practice on a **Raspberry Pi 5 + Raspberry Pi Touch Display 2 (7″)** (portrait-native 720×1280, `ili9881` panel, Goodix `gt911` touch) run in landscape — touch was wrong/dead across half the screen.

## Change

Teach the driver to swap axes, and select the swap/invert flags from the existing `DISPLAY_ROTATION` value.

- `MultiTouch.__init__` gains `swap_xy=False`.
- The X/Y coordinate handling is factored into a pure `MultiTouch._transform_abs(...)` staticmethod. When `swap_xy` is set, a raw panel-X event drives `y_root` and a raw panel-Y event drives `x_root`; the invert flag is chosen by the **destination** axis and the maximum used for inversion is the **source** axis maximum.
- A `MultiTouch.ROTATION_MAP` class constant maps each `DISPLAY_ROTATION` value to `(swap_xy, invert_x, invert_y)`. `zynthian_gui.py` now instantiates the driver from this map instead of the previous hard-coded `Inverted`-only branch.

| `DISPLAY_ROTATION` | rotation | `(swap_xy, invert_x, invert_y)` |
|---|---|---|
| `None`     | 0° (native portrait) | `(False, False, False)` |
| `Right`    | 90° landscape | `(True, False, True)` — **verified on TD2** |
| `Inverted` | 180° | `(False, True, True)` — **unchanged** |
| `Left`     | 270° landscape | `(True, True, False)` — mirror of `Right`, see below |

## Why `DISPLAY_ROTATION` (and not a new variable)

`DISPLAY_ROTATION` is already a touch-only setting:

- In webconf its field is labelled **"Touch Rotation"** (`display_config_handler.py`).
- Its only functional reader is the multitouch instantiation in `zynthian_gui.py` — it has never affected the display.

Display rotation is handled separately (firmware/KMS params and the X11 monitor file generated by zynthian-sys, keyed off `DISPLAY_CONFIG`, not off `DISPLAY_ROTATION`). So adding `Right` / `Left` here completes an existing touch-rotation enum rather than adding new config surface, and it is strictly additive: `zynthian_gui.py` previously special-cased only `Inverted`, with everything else falling through to a plain `MultiTouch(...)`; `None` and `Inverted` map to exactly their previous flag combinations.

I'm happy to switch this to a dedicated variable (e.g. `ZYNTHIAN_TOUCH_SWAP_XY` + invert flags) if maintainers prefer — `multitouch.py` would be untouched and only the small `zynthian_gui.py` selection block would change.

## `Right` is verified; `Left` is not

`Right` `(True, False, True)` was derived from labelled `evtest` corner data on the reference TD2 unit and confirmed working (full width responsive, taps land true). The included test uses that corner data as the oracle.

`Left` (270°) is provided as the exact 180° mirror of `Right` and is checked for that self-consistency in the test, but it has **not** been confirmed on hardware. This is noted in the code (`ROTATION_MAP` comment) and the test. If maintainers would rather not ship an unverified path, `Left` can be dropped to land `Right` only, and added once someone verifies a 270° mounting.

## Tests

New `zyngui/multitouch_rotation_test.py` (runs standalone or under pytest):

```bash
python3 zyngui/multitouch_rotation_test.py
```

Covers: `ROTATION_MAP` keys and the unchanged `None` / `Inverted` flag values (regression lock); `None` = identity; `Inverted` = both axes flipped; `Right` exact mapping against the TD2 corner data plus a per-corner quadrant check ("not mirrored"); and `Left` as the 180° mirror of `Right`. The test stubs `tkinter` / `tkinterweb` / `evdev` / `zynthian_gui_config` so it imports the real class with no GUI, display, or touch hardware present.

## Note on UI exposure (intentional)

This PR does not touch webconf. After it merges, `DISPLAY_ROTATION=Right` / `Left` works but is reachable only by editing `zynthian_envars.sh`; the "Touch Rotation" dropdown still offers only `None` / `Inverted`. Adding those options to the dropdown, plus a TD2 display definition that selects landscape by default, comes in the companion PR (PR 2). The brief window where the capability is env-settable only is intentional.

## Discussion

https://discourse.zynthian.org/t/add-support-for-the-raspberry-pi-touch-display-2-7-inch-screen-to-zynthian-vangelis-feature-request-1704/13332?u=tunagenes
