### PR TITLE
Fix wrong method name and doubling of zynpot + midi learn

### DIFF
--- a/zyngine/ctrldev/zynthian_ctrldev_akai_apc_key25.py
+++ b/zyngine/ctrldev/zynthian_ctrldev_akai_apc_key25.py
@@ -187,6 +187,8 @@ class zynthian_ctrldev_akai_apc_key25(zynthian_ctrldev_akai_apc_key25_mk2):
             zynpot = CCNUM_ZYNPOT.get(ccnum, None)
             if zynpot is not None:
                 self._state_manager.send_cuia("ZYNPOT_ABS", [zynpot, ccval / 127])
+                return True
+            return False
 
         def note_on(self, note, velocity, shifted_override=None):
             if note < 4:

--- a/zyngui/zynthian_gui_base.py
+++ b/zyngui/zynthian_gui_base.py
@@ -567,7 +567,7 @@ class zynthian_gui_base(tkinter.Frame):
             self.zynpot_cb(zynthian_gui_config.layout['ctrl_order'][3], nudge)
             return True
 
-    def zynpot_cb(self, i, val):
+    def zynpot_abs(self, i, val):
         if self.param_editor_zctrl:
             ctrl_order = zynthian_gui_config.layout['ctrl_order']
             if i == ctrl_order[3]:


### PR DESCRIPTION
With these changes the top row of knobs in apc key25 is not available for MIDI learn in device mode anymore. Which would be confusing, since this is meant for zynpot. Apc key 25 mk2 driver already did the right thing.

If one wants to use one of the top knobs for midi learn for use with “PAD+CTRL” mode (shift+SEND), the user can start midi learn, switch to PAD+CTRL mode, turn one of those knobs, and it will be bound as usual.

The other change was the addition of zynpot_abs() to gui_base being misnamed as zynpot_cb() (but luckily, the first in order), so ineffective.

I hope to test the changes within the context of the new image soon.