### PR TITLE
Fix three faults in ZS3_NEXT / ZS3_PREV stepping

### DIFF
--- a/zyngine/zynthian_state_manager.py
+++ b/zyngine/zynthian_state_manager.py
@@ -1826,19 +1826,48 @@ class zynthian_state_manager:
         if zs3_id:
             return self.load_zs3(zs3_id)
 
+    def get_zs3_ids(self):
+        """Get the ZS3 ids that stepping walks, in order
+
+        Excludes 'zs3-0', which is the state the snapshot was saved in rather
+        than a registration, and which the ZS3 screen already lists apart from
+        the saved ZS3s.
+        Returns : List of ZS3 ids
+        """
+
+        return [zs3_id for zs3_id in self.zs3 if zs3_id != "zs3-0"]
+
     def load_next_zs3(self):
+        """Restore the next ZS3, or the first if none is loaded
+
+        Returns : True on success
+        """
+
+        zs3_ids = self.get_zs3_ids()
         try:
-            index = self.get_last_zs3_index() + 1
-        except:
+            index = zs3_ids.index(self.last_zs3_id) + 1
+        except ValueError:
+            # Nothing loaded, or the default state is loaded => start at the first
+            index = 0
+        if index >= len(zs3_ids):
             return False
-        return self.load_zs3_by_index(index)
+        return self.load_zs3(zs3_ids[index])
 
     def load_prev_zs3(self):
+        """Restore the previous ZS3, or the last if none is loaded
+
+        Returns : True on success
+        """
+
+        zs3_ids = self.get_zs3_ids()
         try:
-            index = self.get_last_zs3_index() - 1
-        except:
+            index = zs3_ids.index(self.last_zs3_id) - 1
+        except ValueError:
+            # Nothing loaded, or the default state is loaded => start at the last
+            index = len(zs3_ids) - 1
+        if index < 0:
             return False
-        return self.load_zs3_by_index(index)
+        return self.load_zs3(zs3_ids[index])
 
     # ------------------------------------------------------------------
     # Jackd Info


### PR DESCRIPTION
I'm setting up a Zynthian to step through 30–40 ZS3s from a foot controller for a pantomime
pit band, and hit three faults in `ZS3_NEXT` / `ZS3_PREV` while reading
`zynthian_state_manager.py`. All three are in the same few lines.

**a) Both are no-ops from a cold start.** `get_last_zs3_index()` calls `list.index(None)`
when no ZS3 has been loaded, which raises, and both steppers swallow the exception. So the
pedal does nothing at all after a snapshot loads, until you pick a ZS3 by hand.

**b) Landing on `zs3-0` disarms them again.** Loading it sets `last_zs3_id = None`, which
puts you back in case (a). `zs3-0` is the first key in the dict, so a single press of
`ZS3_PREV` while on the first ZS3 is enough to do it.

**c) The two ends behave differently.** `ZS3_PREV` at index 0 computes `-1`, which Python
reads as the last entry, so it wraps round; `ZS3_NEXT` past the end logs a warning and does
nothing.

## The change

These turned out to be one problem rather than three. Stepping walks the raw `zs3` dict,
which includes `zs3-0`. Stepping over the ZS3s *excluding* `zs3-0`, and treating "no current
ZS3" as start-at-the-appropriate-end rather than as an error, removes all three.

`zs3-0` is the state the snapshot was saved in rather than a registration, and
`zynthian_gui_zs3.py` already lists it apart from the saved ZS3s — so excluding it from
stepping matches what the UI already shows.

After the change: `ZS3_NEXT` from cold loads the first ZS3, `ZS3_PREV` from cold loads the
last, both ends stop rather than one wrapping silently, and normal stepping is unchanged.

## Behaviour change worth flagging

**Stepping can no longer land on `zs3-0`.** Anyone deliberately using the default state as a
step in their sequence loses that. It's what makes (a) and (b) go away, so I think it's the
right call — but it is a change and not only a fix, and I'd rather say so than have you find
it.

`get_last_zs3_index()` is now unused. I've left it in place in case anything out of tree calls
it, but I'm happy to remove it if you'd prefer.

## Testing

**Not run on a Zynthian** — my V5.1 hasn't arrived yet, so please weigh it accordingly.

What I have done: the patched file compiles, and I lifted the three changed methods out of it
and ran them against a stub `state_manager` — so it's the actual code that was exercised, not
a reimplementation. Covered: all three faults above, normal stepping in both directions, and
two degenerate snapshots (a snapshot with only `zs3-0`, and an empty dict) which must return
`False` rather than raise.

## Related

@pft has a branch adding a `ZS3_CYCLE` CUIA which touches the same two functions, and reading
it is what sent me looking at them properly.

The two don't do the same job. His adds cycling under a new CUIA; this fixes the existing
`ZS3_NEXT` / `ZS3_PREV`, which stay broken from cold whether or not `ZS3_CYCLE` exists.
`ZS3_CYCLE` would sit on top of this cleanly — and would get the `zs3-0` handling for free
rather than having to repeat it. Happy to rebase if his lands first.

Discussion this came out of:
https://discourse.zynthian.org/t/is-there-a-performance-mode-for-paging-through-zs3s/13455

