### PR TITLE
Optionally cycle zs3

### DIFF
--- a/zyngine/zynthian_state_manager.py
+++ b/zyngine/zynthian_state_manager.py
@@ -1840,7 +1840,7 @@ class zynthian_state_manager:
 
         return [zs3_id for zs3_id in self.zs3 if zs3_id != "zs3-0"]
 
-    def load_next_zs3(self):
+    def load_next_zs3(self, cycle):
         """Restore the next ZS3, or the first if none is loaded
 
         Returns : True on success
@@ -1855,11 +1855,13 @@ class zynthian_state_manager:
             # Nothing loaded, or the default state is loaded => start at the first
             index = 0
         if index >= len(zs3_ids):
-            #index = 0
-            return False
+            if cycle is not None:
+                index = 0
+            else:
+                return False
         return self.load_zs3(zs3_ids[index])
 
-    def load_prev_zs3(self):
+    def load_prev_zs3(self, cycle):
         """Restore the previous ZS3, or the last if none is loaded
 
         Returns : True on success
@@ -1874,8 +1876,10 @@ class zynthian_state_manager:
             # Nothing loaded, or the default state is loaded => start at the last
             index = len(zs3_ids) - 1
         if index < 0:
-            #index = len(zs3_ids) - 1
-            return False
+            if cycle is not None:
+                index = len(zs3_ids) - 1
+            else:
+                return False
         return self.load_zs3(zs3_ids[index])
 
     # ------------------------------------------------------------------

--- a/zyngui/zynthian_gui.py
+++ b/zyngui/zynthian_gui.py
@@ -1823,10 +1823,10 @@ class zynthian_gui:
                 self.state_manager.load_zs3(params[0])
 
     def cuia_zs3_next(self, params=None):
-        self.state_manager.load_next_zs3()
+        self.state_manager.load_next_zs3(params)
 
     def cuia_zs3_prev(self, params=None):
-        self.state_manager.load_prev_zs3()
+        self.state_manager.load_prev_zs3(params)
 
     # -------------------------------------------------------------------
     # MIDI Learn CUIAS:


### PR DESCRIPTION
    This allows people to cycle (wrap-around) zs3s with cuia
    zs3_next/zs3_prev using a single pedal.

    Default still stops at the beginning or end.