### PR TITLE
ZS3 performance view — an ALT mode of the ZS3 screen

### DIFF
--- a/zyngui/zs3_performance.py
+++ b/zyngui/zs3_performance.py
@@ -1,0 +1,216 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# ******************************************************************************
+# ZYNTHIAN PROJECT: Zynthian GUI
+#
+# ZS3 performance view => decision functions
+#
+# Copyright (C) 2026 Charlie Wakely <ccwakely@gmail.com>
+#
+# ******************************************************************************
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of
+# the License, or any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# For a full copy of the GNU General Public License see the LICENSE.txt file.
+#
+# ******************************************************************************
+
+# This module imports nothing. Everything here answers "given this ZS3 dict and
+# this id, what should the screen say"; zynthian_gui_zs3 does the drawing and
+# none of the deciding. Keeping it import-free is what makes it testable
+# without a Tkinter display or hardware attached.
+
+DEFAULT_ZS3_ID = "zs3-0"
+ELLIPSIS = "…"
+
+
+def parse_zs3_id(zs3_id):
+    """Split a ZS3 id into its parts
+
+    Four id forms exist:
+
+      "zs3-N"  saved with no program change  (state_manager.save_zs3)
+      "*/P"    any channel, program P        (gui_zs3_options.py:242)
+      "C/P"    channel C, program P          (gui_zs3_options.py:244)
+      "P"      bare number, left behind when a program change is *removed*
+               from a "C/P" or "*/P" id, because gui_zs3_options.py:238
+               splits on "/" and keeps only the last part
+
+    C is stored 0-based and returned 1-based, matching what the ZS3 list shows
+    (gui_zs3.py:106 renders CH#{int(parts[0]) + 1}).
+
+    Returns : dict of
+      kind       "unnumbered" | "any_channel" | "channel" | "orphan" | "default"
+      midi_chan  1-based channel, or None for any-channel / unnumbered
+      prog       program change number as displayed, or None
+    """
+
+    if zs3_id == DEFAULT_ZS3_ID:
+        return {"kind": "default", "midi_chan": None, "prog": None}
+
+    if not isinstance(zs3_id, str) or not zs3_id:
+        return {"kind": "unnumbered", "midi_chan": None, "prog": None}
+
+    if "/" in zs3_id:
+        chan_part, _, prog_part = zs3_id.partition("/")
+        prog = _as_int(prog_part)
+        if prog is None:
+            return {"kind": "unnumbered", "midi_chan": None, "prog": None}
+        if chan_part == "*":
+            return {"kind": "any_channel", "midi_chan": None, "prog": prog}
+        chan = _as_int(chan_part)
+        if chan is None:
+            return {"kind": "any_channel", "midi_chan": None, "prog": prog}
+        return {"kind": "channel", "midi_chan": chan + 1, "prog": prog}
+
+    prog = _as_int(zs3_id)
+    if prog is not None:
+        return {"kind": "orphan", "midi_chan": None, "prog": prog}
+
+    return {"kind": "unnumbered", "midi_chan": None, "prog": None}
+
+
+def format_pc_label(zs3_id):
+    """Build the program change label, or "" when the ZS3 has no number
+
+    Formatted as the ZS3 list screen formats it (gui_zs3.py:104-106) so the two
+    faces of this screen cannot disagree about the same ZS3.
+
+    Returns : String
+    """
+
+    parts = parse_zs3_id(zs3_id)
+    if parts["prog"] is None:
+        return ""
+    if parts["midi_chan"] is None:
+        return "PRG#{}".format(parts["prog"])
+    return "CH#{}:PRG#{}".format(parts["midi_chan"], parts["prog"])
+
+
+def cue_ids(zs3):
+    """Get the ZS3 ids in the order stepping walks them
+
+    Dict insertion order, excluding "zs3-0" => the same list
+    state_manager.get_zs3_ids() builds, so the position shown here cannot
+    disagree with where ZS3_NEXT / ZS3_PREV will go.
+
+    Returns : List of ZS3 ids
+    """
+
+    return [key for key in zs3 if key != DEFAULT_ZS3_ID]
+
+
+def first_cue_id(zs3):
+    """Get the first ZS3 in stepping order, or None if there are none
+
+    Named on the "no ZS3 loaded" face so it can say which ZS3 comes first
+    rather than only that none is loaded.
+
+    Returns : ZS3 id or None
+    """
+
+    cues = cue_ids(zs3 or {})
+    return cues[0] if cues else None
+
+
+def cue_position(zs3, zs3_id):
+    """Get the position of a ZS3 in stepping order, 1-based, and the total
+
+    position is 0 when the id is not in the stepping order: nothing loaded, the
+    default state, or an id absent from this snapshot.
+
+    Returns : (position, total)
+    """
+
+    cues = cue_ids(zs3)
+    try:
+        return cues.index(zs3_id) + 1, len(cues)
+    except ValueError:
+        return 0, len(cues)
+
+
+def ellipsize(text, limit):
+    """Shorten text to limit characters, ending in an ellipsis
+
+    Never clip: a title running off the edge of the screen reads as a different
+    title, so seeing that a name has been shortened matters more than seeing
+    the end of it.
+
+    Returns : String
+    """
+
+    if text is None:
+        return ""
+    text = str(text)
+    if limit is None or limit <= 0:
+        return ""
+    if len(text) <= limit:
+        return text
+    if limit == 1:
+        return ELLIPSIS
+    return text[:limit - 1].rstrip() + ELLIPSIS
+
+
+def performance_state(zs3, zs3_id):
+    """Build everything the performance face draws
+
+    zs3     : The state manager's zs3 dict
+    zs3_id  : The current ZS3 id, as carried by SS_LOAD_ZS3, or None
+
+    Titles are returned whole. How much of one fits on screen depends on the
+    font and the panel, which this module deliberately cannot see, so the
+    screen measures and calls ellipsize() itself.
+
+    For the default state SS_LOAD_ZS3 carries "zs3-0" while last_zs3_id is set
+    to None, so the two disagree; both are accepted here and render the same.
+
+    Never raises: an unknown id, an empty snapshot and None are all states this
+    screen has to survive mid-performance.
+
+    Returns : dict of title, pc_label, position, total, position_label,
+              is_default, is_loaded, is_known
+    """
+
+    zs3 = zs3 or {}
+    is_default = zs3_id == DEFAULT_ZS3_ID
+    is_loaded = bool(zs3_id) and not is_default
+    entry = zs3.get(zs3_id) if isinstance(zs3, dict) else None
+
+    if not is_loaded:
+        title = "No cue" if zs3_id is None else "Default state"
+    elif entry is None:
+        # get_zs3_title() falls back to the raw id; do the same rather than
+        # invent a placeholder.
+        title = str(zs3_id)
+    else:
+        title = entry.get("title") or str(zs3_id)
+
+    position, total = cue_position(zs3, zs3_id)
+
+    return {
+        "title": title,
+        "pc_label": format_pc_label(zs3_id) if is_loaded else "",
+        "position": position,
+        "total": total,
+        "position_label": "{} / {}".format(position, total) if position else "- / {}".format(total),
+        "is_default": is_default,
+        "is_loaded": is_loaded,
+        "is_known": entry is not None,
+    }
+
+
+def _as_int(text):
+    try:
+        return int(text)
+    except (TypeError, ValueError):
+        return None
+
+# ------------------------------------------------------------------------------

--- a/zyngui/zynthian_gui_zs3.py
+++ b/zyngui/zynthian_gui_zs3.py
@@ -25,10 +25,12 @@
 
 import tkinter
 import logging
+from tkinter import font as tkFont
 
 # Zynthian specific modules
 from zyngine.zynthian_signal_manager import zynsigman
 from zyngui import zynthian_gui_config
+from zyngui import zs3_performance
 from zyngui.zynthian_gui_selector_info import zynthian_gui_selector_info
 
 # ------------------------------------------------------------------------------
@@ -48,6 +50,35 @@ class zynthian_gui_zs3(zynthian_gui_selector_info):
                                                fg=zynthian_gui_config.color_ml,
                                                bg=zynthian_gui_config.color_panel_bg)
 
+        # ALT mode draws a performance face over the list: the current ZS3's
+        # title, large enough to read from across a room, its program change
+        # and its position in the stepping order. It is display only, and holds
+        # no state of its own beyond the id last announced by SS_LOAD_ZS3.
+        self.perf_zs3_id = None
+        self.perf_canvas = tkinter.Canvas(
+            self.main_frame,
+            bd=0,
+            highlightthickness=0,
+            bg=zynthian_gui_config.color_bg)
+        self.perf_title = self.perf_canvas.create_text(
+            0, 0,
+            anchor=tkinter.CENTER,
+            justify=tkinter.CENTER,
+            fill=zynthian_gui_config.color_tx)
+        self.perf_subtitle = self.perf_canvas.create_text(
+            0, 0,
+            anchor=tkinter.CENTER,
+            justify=tkinter.CENTER,
+            fill=zynthian_gui_config.color_tx_off)
+        self.perf_prog = self.perf_canvas.create_text(
+            0, 0,
+            anchor=tkinter.SW,
+            fill=zynthian_gui_config.color_ml)
+        self.perf_pos = self.perf_canvas.create_text(
+            0, 0,
+            anchor=tkinter.SE,
+            fill=zynthian_gui_config.color_ml)
+
     def show_waiting_label(self):
         if self.wide:
             padx = (0, 2)
@@ -65,6 +96,8 @@ class zynthian_gui_zs3(zynthian_gui_selector_info):
                 zynsigman.S_STATE_MAN, zynsigman.SS_LOAD_ZS3, self.cb_load_zs3)
             zynsigman.register_queued(
                 zynsigman.S_STATE_MAN, zynsigman.SS_SAVE_ZS3, self.cb_save_zs3)
+            self.perf_zs3_id = self.zyngui.state_manager.last_zs3_id
+            self.show_performance(self.alt_mode)
             return True
         else:
             return False
@@ -114,6 +147,8 @@ class zynthian_gui_zs3(zynthian_gui_selector_info):
         super().fill_list()
 
     def cb_load_zs3(self, zs3_id):
+        self.perf_zs3_id = zs3_id
+        self.update_performance()
         if self.shown:
             for i, row in enumerate(self.list_data):
                 if row[0] == zs3_id:
@@ -195,5 +230,156 @@ class zynthian_gui_zs3(zynthian_gui_selector_info):
 
     def get_alt_mode(self):
         return self.alt_mode
+
+    def cuia_toggle_alt_mode(self, params=None):
+        super().cuia_toggle_alt_mode(params)
+        self.show_performance(self.alt_mode)
+        return True
+
+    # In the performance face the list is hidden, so the arrows have no list to
+    # move. Repurpose them to step cues — a manual backup for the foot pedal if
+    # it fails or is kicked out of reach. Down/Right advance, Up/Left go back,
+    # both wrapping, matching the pedal's ZS3_NEXT 1 / ZS3_PREV 1. Outside ALT
+    # mode they fall through to normal list navigation.
+    def arrow_down(self):
+        if self.alt_mode:
+            self.zyngui.state_manager.load_next_zs3(True)
+            return True
+        return super().arrow_down()
+
+    def arrow_up(self):
+        if self.alt_mode:
+            self.zyngui.state_manager.load_prev_zs3(True)
+            return True
+        return super().arrow_up()
+
+    def arrow_right(self):
+        if self.alt_mode:
+            self.zyngui.state_manager.load_next_zs3(True)
+            return True
+
+    def arrow_left(self):
+        if self.alt_mode:
+            self.zyngui.state_manager.load_prev_zs3(True)
+            return True
+
+    def show_performance(self, show):
+        """Swap between the ZS3 list and the performance face
+
+        show: True for the performance face, False for the list
+        """
+
+        if show:
+            self.listbox.grid_remove()
+            self.info_canvas.grid_remove()
+            # The PC-learn banner sits along the bottom and would cover the
+            # position readout; the performance face takes no input, so hide it.
+            self.hide_waiting_label()
+            self.show_sidebar(False)
+            self.perf_canvas.grid(
+                row=self.layout['list_pos'][0],
+                column=self.layout['list_pos'][1],
+                rowspan=self.layout['rows'],
+                columnspan=2,
+                padx=self.padx,
+                pady=self.pady,
+                sticky="news")
+            self.update_performance()
+        else:
+            self.perf_canvas.grid_remove()
+            self.listbox.grid()
+            self.info_canvas.grid()
+            self.show_sidebar(True)
+            # Restore the banner only if PC-learn is still waiting for a change.
+            if self.zyngui.state_manager.midi_learn_state:
+                self.show_waiting_label()
+
+    def update_layout(self):
+        super().update_layout()
+        self.update_performance()
+
+    def update_performance(self):
+        """Redraw the performance face
+
+        Called on ZS3 load and save, on entering ALT mode, and on geometry
+        changes. Never polled: with no ZS3 activity this screen does nothing.
+        """
+
+        if not self.alt_mode:
+            return
+
+        state = zs3_performance.performance_state(
+            self.zyngui.state_manager.zs3, self.perf_zs3_id)
+
+        # 44px at 800x480, which is what reads from ten feet away. Taken from
+        # the configured font size rather than hardcoded, so a themed or
+        # differently sized panel scales with it.
+        title_fs = int(2.2 * zynthian_gui_config.font_size)
+        label_fs = int(1.1 * zynthian_gui_config.font_size)
+        # The bottom line (program change + position) is glanced at from a few
+        # feet mid-performance, so it is larger than the "no cue" hint above it.
+        bottom_fs = int(1.6 * zynthian_gui_config.font_size)
+        title_font = tkFont.Font(family=zynthian_gui_config.font_family, size=title_fs)
+        pad = int(0.6 * zynthian_gui_config.font_size)
+
+        if state["is_loaded"]:
+            title = state["title"]
+            subtitle = ""
+        elif state["is_default"]:
+            title = "DEFAULT STATE"
+            subtitle = ""
+        else:
+            # Nothing loaded: at power on, and after a snapshot load, until the
+            # first step. A statement rather than an affordance, since the
+            # pedal reaches the first ZS3 from here on its own.
+            title = "NO CUE"
+            first_id = zs3_performance.first_cue_id(self.zyngui.state_manager.zs3)
+            if first_id:
+                subtitle = "press the pedal to start — {}".format(
+                    self.zyngui.state_manager.get_zs3_title(first_id))
+            else:
+                subtitle = "no ZS3s in this snapshot"
+
+        self.perf_canvas.itemconfigure(
+            self.perf_title,
+            font=(zynthian_gui_config.font_family, title_fs),
+            text=self.fit_title(title, title_font, self.width - 2 * pad))
+        self.perf_canvas.coords(self.perf_title, self.width // 2, int(0.38 * self.height))
+
+        self.perf_canvas.itemconfigure(
+            self.perf_subtitle,
+            font=(zynthian_gui_config.font_family, label_fs),
+            text=subtitle)
+        self.perf_canvas.coords(self.perf_subtitle, self.width // 2, int(0.62 * self.height))
+
+        self.perf_canvas.itemconfigure(
+            self.perf_prog,
+            font=(zynthian_gui_config.font_family, bottom_fs),
+            text=state["pc_label"])
+        self.perf_canvas.coords(self.perf_prog, pad, self.height - pad)
+
+        self.perf_canvas.itemconfigure(
+            self.perf_pos,
+            font=(zynthian_gui_config.font_family, bottom_fs),
+            text=state["position_label"])
+        self.perf_canvas.coords(self.perf_pos, self.width - pad, self.height - pad)
+
+    def fit_title(self, title, font, max_width):
+        """Shorten a title until it fits the available width
+
+        How many characters fit is a rendering question and needs font metrics,
+        so it lives here; how to shorten a string is zs3_performance's.
+
+        Returns : String
+        """
+
+        if max_width < 1 or font.measure(title) <= max_width:
+            return title
+        limit = len(title)
+        text = title
+        while limit > 1 and font.measure(text) > max_width:
+            limit -= 1
+            text = zs3_performance.ellipsize(title, limit)
+        return text
 
 # -------------------------------------------------------------------------------


### PR DESCRIPTION
**What this is**

An ALT-mode rendering of the existing ZS3 screen that shows the current cue large enough to read from across a room: a big title, its program-change number, and its position in the running order. Aimed at live performance — my case is a pantomime pit band stepping 30–40 ZS3s from a foot pedal, where the standard list is unreadable at a glance mid-show.

Built as an **ALT mode of `zynthian_gui_zs3`** rather than a new screen, per @jofemodo's suggestion earlier in [thread 13455](https://discourse.zynthian.org/t/is-there-a-performance-mode-for-paging-through-zs3s/13455): a rendering branch on the screen we already have, so it reuses the house topbar (DPM + status area) and the existing `get_alt_mode()` / base-class toggle. No new CUIA, no new screen registration.

**What it adds**

- **`zyngui/zs3_performance.py`** (new) — the view's decisions as plain functions with **no Zynthian imports**: PC label from the ZS3 id (`*/N`, `C/N`, `zs3-N`, bare number), position/total from dict order (the same order stepping walks), ellipsis fitting, and the assembled performance state. Import-free so it's unit-testable without Tkinter or hardware.
- **`zyngui/zynthian_gui_zs3.py`** — the ALT rendering branch: a canvas drawn over the list showing the title (~44 px at 800×480, scaled from the configured font size), the PC label (`CH#…:PRG#…`), and position (`N / M`). It **redraws only on `SS_LOAD_ZS3` / `SS_SAVE_ZS3` and geometry changes** — no polling, and no work in any MIDI or audio path.

**Details**

- A **"NO CUE"** state (nothing loaded yet) that names the first cue in the order.
- Titles **auto-ellipsize to the panel width** (measured with font metrics, never clipped off-screen).
- **Arrow keys step cues while in ALT mode** (down/right → next, up/left → previous, wrapping) — a manual backup if the foot pedal fails or is out of reach. Outside ALT mode the arrows do normal list navigation.
- Fonts and colours come from `zynthian_gui_config`; the view holds no stepping logic of its own — it observes the signals and draws.

**Testing / status**

- Tested on a V5.1 (Pi 5) running `vangelis`, on real hardware.
- The decision module has unit tests in my repo (import-free, no mocks). Happy to move them wherever suits.

**Follow-up (separate PR):** a small change to `save_zs3` to carry a per-cue *note* — as agreed in [the thread](https://discourse.zynthian.org/t/is-there-a-performance-mode-for-paging-through-zs3s/13455) — would add an optional note line to this view. Kept separate so this PR only references fields that already exist.
