### PR TITLE
Add an optional note to each ZS3, shown by the performance view

### DIFF
--- a/zyngine/zynthian_state_manager.py
+++ b/zyngine/zynthian_state_manager.py
@@ -1341,6 +1341,32 @@ class zynthian_state_manager:
     def set_zs3_title(self, zs3_id, title):
         self.zs3[zs3_id]["title"] = title
 
+    def get_zs3_note(self, zs3_id=None):
+        """Get ZS3 note
+
+        zs3_id : ZS3 ID (default: Use last loaded zs3)
+        Returns : Note as string, empty if the ZS3 has none
+        """
+
+        try:
+            if zs3_id is None:
+                zs3_id = self.last_zs3_id
+            return self.zs3[zs3_id].get("note", "")
+        except:
+            return ""
+
+    def set_zs3_note(self, zs3_id, note):
+        """Set ZS3 note
+
+        zs3_id : ZS3 ID
+        note : Note as string. An empty note removes the key.
+        """
+
+        if note:
+            self.zs3[zs3_id]["note"] = note
+        else:
+            self.zs3[zs3_id].pop("note", None)
+
     def toggle_zs3_restore_flag(self, zs3_id, type, id=None):
         zs3_state = self.zs3[zs3_id]
         if type == "midi_learn":
@@ -1601,6 +1627,7 @@ class zynthian_state_manager:
         omit_processors = []
         omit_chains = []
         restore_midi_learn = False
+        note = ""
         if zs3_id in self.zs3:
             zs3 = self.zs3[zs3_id]
             if "processors" in zs3:
@@ -1612,6 +1639,7 @@ class zynthian_state_manager:
                     if "restore" in chain and not chain["restore"]:
                         omit_chains.append(chain_id)
             restore_midi_learn = zs3.get("restore_midi_learn", False)
+            note = zs3.get("note", "")
 
         # Initialise zs3
         self.zs3[zs3_id] = {
@@ -1621,6 +1649,8 @@ class zynthian_state_manager:
         }
         if restore_midi_learn:
             self.zs3[zs3_id]["restore_midi_learn"] = True
+        if note:
+            self.zs3[zs3_id]["note"] = note
 
         chain_states = {}
         for chain_id, chain in self.chain_manager.chains.items():

--- a/zyngui/zs3_performance.py
+++ b/zyngui/zs3_performance.py
@@ -159,6 +159,23 @@ def ellipsize(text, limit):
     return text[:limit - 1].rstrip() + ELLIPSIS
 
 
+def cue_note(entry):
+    """Get the note attached to a ZS3, or "" if it has none
+
+    entry : A ZS3 entry from the state manager's zs3 dict, or None
+
+    The note is optional and most ZS3s will not have one, so an absent key, an
+    empty string and a missing entry all give the same empty result and the
+    screen simply draws nothing.
+
+    Returns : String
+    """
+
+    if not isinstance(entry, dict):
+        return ""
+    return entry.get("note") or ""
+
+
 def performance_state(zs3, zs3_id):
     """Build everything the performance face draws
 
@@ -175,7 +192,7 @@ def performance_state(zs3, zs3_id):
     Never raises: an unknown id, an empty snapshot and None are all states this
     screen has to survive mid-performance.
 
-    Returns : dict of title, pc_label, position, total, position_label,
+    Returns : dict of title, note, pc_label, position, total, position_label,
               is_default, is_loaded, is_known
     """
 
@@ -197,6 +214,7 @@ def performance_state(zs3, zs3_id):
 
     return {
         "title": title,
+        "note": cue_note(entry),
         "pc_label": format_pc_label(zs3_id) if is_loaded else "",
         "position": position,
         "total": total,

--- a/zyngui/zynthian_gui_zs3.py
+++ b/zyngui/zynthian_gui_zs3.py
@@ -51,9 +51,10 @@ class zynthian_gui_zs3(zynthian_gui_selector_info):
                                                bg=zynthian_gui_config.color_panel_bg)
 
         # ALT mode draws a performance face over the list: the current ZS3's
-        # title, large enough to read from across a room, its program change
-        # and its position in the stepping order. It is display only, and holds
-        # no state of its own beyond the id last announced by SS_LOAD_ZS3.
+        # title, large enough to read from across a room, its note, its program
+        # change and its position in the stepping order. It is display only,
+        # and holds no state of its own beyond the id last announced by
+        # SS_LOAD_ZS3.
         self.perf_zs3_id = None
         self.perf_canvas = tkinter.Canvas(
             self.main_frame,
@@ -319,12 +320,20 @@ class zynthian_gui_zs3(zynthian_gui_selector_info):
         # The bottom line (program change + position) is glanced at from a few
         # feet mid-performance, so it is larger than the "no cue" hint above it.
         bottom_fs = int(1.6 * zynthian_gui_config.font_size)
+        note_fs = int(1.5 * zynthian_gui_config.font_size)
         title_font = tkFont.Font(family=zynthian_gui_config.font_family, size=title_fs)
         pad = int(0.6 * zynthian_gui_config.font_size)
 
+        # The note and the "no cue" hint share one line: only one of the two can
+        # ever apply. The note is the larger of the two and sits closer to the
+        # title, because it is read at the same distance as the cue it belongs
+        # to; the hint is only read standing at the box.
+        subtitle_fs = label_fs
+
         if state["is_loaded"]:
             title = state["title"]
-            subtitle = ""
+            subtitle = state["note"]
+            subtitle_fs = note_fs
         elif state["is_default"]:
             title = "DEFAULT STATE"
             subtitle = ""
@@ -346,11 +355,15 @@ class zynthian_gui_zs3(zynthian_gui_selector_info):
             text=self.fit_title(title, title_font, self.width - 2 * pad))
         self.perf_canvas.coords(self.perf_title, self.width // 2, int(0.38 * self.height))
 
+        # Wrap rather than run off the edges: a note is free text and can be
+        # longer than a title, and losing the end of one silently is worse than
+        # spending a second line on it.
         self.perf_canvas.itemconfigure(
             self.perf_subtitle,
-            font=(zynthian_gui_config.font_family, label_fs),
+            font=(zynthian_gui_config.font_family, subtitle_fs),
+            width=self.width - 2 * pad,
             text=subtitle)
-        self.perf_canvas.coords(self.perf_subtitle, self.width // 2, int(0.62 * self.height))
+        self.perf_canvas.coords(self.perf_subtitle, self.width // 2, int(0.52 * self.height))
 
         self.perf_canvas.itemconfigure(
             self.perf_prog,

--- a/zyngui/zynthian_gui_zs3_options.py
+++ b/zyngui/zynthian_gui_zs3_options.py
@@ -63,19 +63,20 @@ class zynthian_gui_zs3_options(zynthian_gui_selector_info):
             self.list_data.append((self.zs3_restoring_submenu, 1, "Restore options...", ["Select which elements will be restored from this ZS3.", "zs3_settings.png"]))
             self.list_data.append((self.zs3_update, 2, "Overwrite", ["Save current state, overwritting this ZS3.", "zs3_overwrite.png"]))
             self.list_data.append((self.zs3_rename, 3, "Rename", ["Rename this ZS3.", "zs3_rename.png"]))
-            self.list_data.append((self.zs3_delete, 4, "Delete", ["Delete this ZS3.", "zs3_delete.png"]))
+            self.list_data.append((self.zs3_note, 4, "Note", ["Add a note to this ZS3, shown by the ZS3 performance view.", "zs3_rename.png"]))
+            self.list_data.append((self.zs3_delete, 5, "Delete", ["Delete this ZS3.", "zs3_delete.png"]))
 
             if "/" in self.zs3_id:
                 if self.prog_num:
-                    self.list_data.append((self.zs3_prog_num, 5, f"Program Change Number [{self.prog_num - 1}]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
+                    self.list_data.append((self.zs3_prog_num, 6, f"Program Change Number [{self.prog_num - 1}]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
                 else:
-                    self.list_data.append((self.zs3_prog_num, 5, "Program Change Number [None]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
+                    self.list_data.append((self.zs3_prog_num, 6, "Program Change Number [None]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
                 if self.prog_chan:
-                    self.list_data.append((self.zs3_prog_chan, 6, f"Program Change Channel [{self.prog_chan}]", ["Assign MIDI Program Change channel to this ZS3.", "zs3_overwrite.png"]))
+                    self.list_data.append((self.zs3_prog_chan, 7, f"Program Change Channel [{self.prog_chan}]", ["Assign MIDI Program Change channel to this ZS3.", "zs3_overwrite.png"]))
                 else:
-                    self.list_data.append((self.zs3_prog_chan, 6, "Program Change Channel [Any]", ["Assign MIDI Program Change channel to this ZS3.", "zs3_overwrite.png"]))
+                    self.list_data.append((self.zs3_prog_chan, 7, "Program Change Channel [Any]", ["Assign MIDI Program Change channel to this ZS3.", "zs3_overwrite.png"]))
             elif id != "zs3-0":
-                self.list_data.append((self.zs3_prog_num, 5, "Program Change Number [None]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
+                self.list_data.append((self.zs3_prog_num, 6, "Program Change Number [None]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
             self.preselect_last_action()
         super().fill_list()
 
@@ -191,6 +192,15 @@ class zynthian_gui_zs3_options(zynthian_gui_selector_info):
     def zs3_rename_cb(self, title):
         logging.info("Renaming ZS3 '{}'".format(self.zs3_id))
         self.zyngui.state_manager.set_zs3_title(self.zs3_id, title)
+        self.zyngui.close_screen()
+
+    def zs3_note(self):
+        note = self.zyngui.state_manager.get_zs3_note(self.zs3_id)
+        self.zyngui.show_keyboard(self.zs3_note_cb, note)
+
+    def zs3_note_cb(self, note):
+        logging.info("Setting note for ZS3 '{}'".format(self.zs3_id))
+        self.zyngui.state_manager.set_zs3_note(self.zs3_id, note)
         self.zyngui.close_screen()
 
     def zs3_update(self):

--- a/zynthian_state_schema.py
+++ b/zynthian_state_schema.py
@@ -69,6 +69,7 @@ ZynthianState = {
     "zs3": {  # Dictionary of ZS3's indexed by chan/prog or ZS3-x
         "zs3-0": {  # ZS3 state when snapshot saved
             "title": "Last state",  # ZS3 title
+            "note": "Capo 2, watch the MD",  # Optional ZS3 note, shown by the performance view
             "active_chain": "1", # Optional active chain id (overides base value)
             "restore_midi_learn": False, # Optional restore midi CC binding (Default: False)
             "processors": {  # Dictionary of processor settings


### PR DESCRIPTION
Follow-on to #594, which added the ZS3 performance view. This adds the one thing that view
was designed around but could not reference until the field existed: an optional free-text
note on a ZS3.

A ZS3 title has to stay short enough to read at a glance, so there is nowhere to put the
things a player actually needs at that moment — which sound the pedal is about to reach, a
tempo, a cue to watch for. I'm running 30–40 ZS3s from a foot controller for a pantomime pit
band, and the note is what turns the performance view from "which cue is this" into something
you can actually play from.

You suggested the ZS3 itself as the right home for it on the forum:

> I think the ZS3 data is the right place for the note. Together with the title and other ZS3
> related info.

So that is where it lives, and it travels with the snapshot without any new state of its own.

## The change

- **`zynthian_state_manager.py`** — `get_zs3_note()` / `set_zs3_note()` beside the title pair,
  and the note is carried across the `save_zs3()` rebuild.
- **`zynthian_gui_zs3_options.py`** — a *Note* entry beside *Rename*, reusing the on-screen
  keyboard.
- **`zs3_performance.py`** — `cue_note()`, and `note` in what `performance_state()` returns.
- **`zynthian_gui_zs3.py`** — the performance view draws it.
- **`zynthian_state_schema.py`** — the new key documented alongside `title`.

Two details worth pointing at:

**`save_zs3()` rebuilds the ZS3 entry from scratch**, so a note has to be carried across an
overwrite the way `title` already is. It follows the existing `restore_midi_learn` pattern
rather than inventing a second one.

**The key is only written when a note is actually set.** A ZS3 with no note has no `note` key,
so existing snapshots are unchanged and nothing has to be migrated.

In the performance view the note shares the line the "no cue" hint uses, since only one of
those two can ever apply — no extra furniture on the screen.

## Tested

On a V5.1 running Vangelis. A note typed into a cue on the touchscreen shows on the
performance face; it survives *Overwrite* on that same ZS3, which is the case this change
exists for, since `save_zs3()` rebuilds the entry; and it survives a full round trip out to
`last_state.zss` and back after a restart. Comparing the snapshot before and after, the only
difference across all eleven ZS3s is the single added `note` key on the one cue, with the ZS3
order unchanged.

One loose end: the *Note* menu entry reuses `zs3_rename.png`, since there is no note icon in
the set. Happy to swap it for a dedicated one if you would like to draw it.
