### PR TITLE
Give the ZS3 performance view a colour hierarchy

### DIFF
--- a/zyngui/zynthian_gui_zs3.py
+++ b/zyngui/zynthian_gui_zs3.py
@@ -64,20 +64,26 @@ class zynthian_gui_zs3(zynthian_gui_selector_info):
             0, 0,
             anchor=tkinter.CENTER,
             justify=tkinter.CENTER,
-            fill=zynthian_gui_config.color_tx)
+            fill=zynthian_gui_config.color_ml)
         self.perf_subtitle = self.perf_canvas.create_text(
             0, 0,
             anchor=tkinter.CENTER,
             justify=tkinter.CENTER,
             fill=zynthian_gui_config.color_tx_off)
+        # The one colour here not taken from zynthian_gui_config: the palette
+        # has a single green, color_hl (#00c000), and nothing dimmer in that
+        # hue, and color_hl is bright enough to be part of what this is fixing.
+        # Happy to use color_off instead, or to add a ZYNTHIAN_UI_COLOR_*
+        # constant for it - see the pull request.
+        color_readout = "#008000"
         self.perf_prog = self.perf_canvas.create_text(
             0, 0,
             anchor=tkinter.SW,
-            fill=zynthian_gui_config.color_ml)
+            fill=color_readout)
         self.perf_pos = self.perf_canvas.create_text(
             0, 0,
             anchor=tkinter.SE,
-            fill=zynthian_gui_config.color_ml)
+            fill=color_readout)
 
     def show_waiting_label(self):
         if self.wide:
@@ -268,6 +274,17 @@ class zynthian_gui_zs3(zynthian_gui_selector_info):
 
         show: True for the performance face, False for the list
         """
+
+        # The topbar stays the house topbar, but during a show its title is
+        # furniture: dim it so the cue name is the brightest thing on screen.
+        # Set it the way set_title() does rather than calling set_title(), which
+        # silently early-returns under its own 30fps rate limit.
+        if self.topbar_allowed:
+            if show:
+                self.title_fg = zynthian_gui_config.color_off
+            else:
+                self.title_fg = zynthian_gui_config.color_panel_tx
+            self.label_select_path.config(fg=self.title_fg)
 
         if show:
             self.listbox.grid_remove()


### PR DESCRIPTION
A follow-up to the ZS3 performance view. It does not depend on #595 (the ZS3 cue note) and the
two can be taken in either order, but #595 is worth reading first: the note is another thing
this hierarchy has to make room for.

Playing from the view on a real stage showed up something the mock-ups never could: everything
on it carries roughly equal visual weight. The cue title is white, the two readouts along the
bottom are yellow and rather loud, and the topbar title is the same white as the cue name. In
a dark pit the eye has to hunt for the one thing that actually matters mid-number, which is
which cue you are on.

This orders the screen by how urgently each part is needed:

- **The cue title takes the yellow**, so it leads. It is the only thing on this screen anyone
  reads at a glance from a distance.
- **The program change and position readouts go green and dimmer.** You need to be able to
  find them when you go looking — "am I at 12 of 38?" — but they should not compete with the
  cue name when you are not.
- **The topbar title dims while the performance face is showing**, and is restored on the way
  out. This uses the per-screen `fg` that `set_title()` already supports, so it touches
  nothing global and no other screen changes.

**The status area is deliberately left alone.** The DPM and its indicators are house furniture
that every screen carries, and a single screen has no business restyling them.

## One thing I would like your opinion on

The readout green is a hardcoded `#008000`, which nothing else on this screen is — every other
colour comes from `zynthian_gui_config`. That is because the palette has exactly one green,
`color_hl` (`#00c000`), and nothing dimmer in that hue, and `color_hl` is bright enough to be
part of the problem being fixed here.

Three ways to resolve it, and I do not want to guess which you would prefer:

1. Use `color_off` (`#5a626d`) instead. Palette-clean, but it is a slate grey rather than a
   green.
2. Add a constant to `zynthian_gui_config`, in keeping with the rest of the palette being
   overridable by `ZYNTHIAN_UI_COLOR_*`.
3. Keep `color_hl` and accept the brighter green.

Say which you would rather have and I will change it — or if you would prefer the colours left
as they are entirely, this PR can simply be closed; the cue note PR does not depend on it.
