### PR TITLE
Add a way to reorder ZS3s from the ZS3 options menu

### DIFF
--- a/zyngine/zynthian_state_manager.py
+++ b/zyngine/zynthian_state_manager.py
@@ -1778,6 +1778,41 @@ class zynthian_state_manager:
         except:
             logging.info("Tried to remove non-existant ZS3")
 
+    def move_zs3(self, zs3_id, index):
+        """Move a ZS3 within the stepping order
+
+        Stepping and the ZS3 screen both walk the zs3 dictionary in insertion
+        order, so reordering is rebuilding that dictionary with its keys in a
+        new order. 'zs3-0' keeps whatever slot it had: it is not part of the
+        stepping order, and the ZS3 screen lists it apart from the saved ZS3s.
+
+        zs3_id : ZS3 ID to move
+        index : New position, zero-based, among the ZS3s that stepping walks
+        Returns : True if the order changed
+        """
+
+        zs3_ids = self.get_zs3_ids()
+        try:
+            current = zs3_ids.index(zs3_id)
+        except ValueError:
+            logging.info(f"Tried to move non-existent ZS3 '{zs3_id}'")
+            return False
+        index = min(max(index, 0), len(zs3_ids) - 1)
+        if index == current:
+            return False
+        zs3_ids.insert(index, zs3_ids.pop(current))
+
+        moved = iter(zs3_ids)
+        zs3 = {}
+        for key in self.zs3:
+            if key == "zs3-0":
+                zs3[key] = self.zs3[key]
+            else:
+                new_key = next(moved)
+                zs3[new_key] = self.zs3[new_key]
+        self.zs3 = zs3
+        return True
+
     def reset_zs3(self):
         """Remove all ZS3"""
 

--- a/zyngui/zynthian_gui_zs3_options.py
+++ b/zyngui/zynthian_gui_zs3_options.py
@@ -64,19 +64,21 @@ class zynthian_gui_zs3_options(zynthian_gui_selector_info):
             self.list_data.append((self.zs3_update, 2, "Overwrite", ["Save current state, overwritting this ZS3.", "zs3_overwrite.png"]))
             self.list_data.append((self.zs3_rename, 3, "Rename", ["Rename this ZS3.", "zs3_rename.png"]))
             self.list_data.append((self.zs3_note, 4, "Note", ["Add a note to this ZS3, shown by the ZS3 performance view.", "zs3_rename.png"]))
-            self.list_data.append((self.zs3_delete, 5, "Delete", ["Delete this ZS3.", "zs3_delete.png"]))
+            if len(self.zyngui.state_manager.get_zs3_ids()) > 1:
+                self.list_data.append((self.zs3_position, 5, f"Position [{self.get_position() + 1}]", ["Move this ZS3 within the order that ZS3_NEXT / ZS3_PREV step through.", "zs3_settings.png"]))
+            self.list_data.append((self.zs3_delete, 6, "Delete", ["Delete this ZS3.", "zs3_delete.png"]))
 
             if "/" in self.zs3_id:
                 if self.prog_num:
-                    self.list_data.append((self.zs3_prog_num, 6, f"Program Change Number [{self.prog_num - 1}]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
+                    self.list_data.append((self.zs3_prog_num, 7, f"Program Change Number [{self.prog_num - 1}]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
                 else:
-                    self.list_data.append((self.zs3_prog_num, 6, "Program Change Number [None]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
+                    self.list_data.append((self.zs3_prog_num, 7, "Program Change Number [None]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
                 if self.prog_chan:
-                    self.list_data.append((self.zs3_prog_chan, 7, f"Program Change Channel [{self.prog_chan}]", ["Assign MIDI Program Change channel to this ZS3.", "zs3_overwrite.png"]))
+                    self.list_data.append((self.zs3_prog_chan, 8, f"Program Change Channel [{self.prog_chan}]", ["Assign MIDI Program Change channel to this ZS3.", "zs3_overwrite.png"]))
                 else:
-                    self.list_data.append((self.zs3_prog_chan, 7, "Program Change Channel [Any]", ["Assign MIDI Program Change channel to this ZS3.", "zs3_overwrite.png"]))
+                    self.list_data.append((self.zs3_prog_chan, 8, "Program Change Channel [Any]", ["Assign MIDI Program Change channel to this ZS3.", "zs3_overwrite.png"]))
             elif id != "zs3-0":
-                self.list_data.append((self.zs3_prog_num, 6, "Program Change Number [None]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
+                self.list_data.append((self.zs3_prog_num, 7, "Program Change Number [None]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
             self.preselect_last_action()
         super().fill_list()
 
@@ -201,6 +203,27 @@ class zynthian_gui_zs3_options(zynthian_gui_selector_info):
     def zs3_note_cb(self, note):
         logging.info("Setting note for ZS3 '{}'".format(self.zs3_id))
         self.zyngui.state_manager.set_zs3_note(self.zs3_id, note)
+        self.zyngui.close_screen()
+
+    def get_position(self):
+        """Get this ZS3's zero-based position in the stepping order, or -1"""
+
+        try:
+            return self.zyngui.state_manager.get_zs3_ids().index(self.zs3_id)
+        except ValueError:
+            return -1
+
+    def zs3_position(self):
+        position = self.get_position()
+        if position < 0:
+            return
+        total = len(self.zyngui.state_manager.get_zs3_ids())
+        labels = [str(i + 1) for i in range(total)]
+        self.enable_param_editor(self, 'zs3_position', {'name': 'Position', 'labels': labels, 'value': position}, self.on_zs3_position)
+
+    def on_zs3_position(self, value):
+        logging.info("Moving ZS3 '{}' to position {}".format(self.zs3_id, value + 1))
+        self.zyngui.state_manager.move_zs3(self.zs3_id, value)
         self.zyngui.close_screen()
 
     def zs3_update(self):


### PR DESCRIPTION
`ZS3_NEXT` / `ZS3_PREV` step through the `zs3` dictionary in insertion order, and there has
been no way to change that order. So the order ZS3s are created in is the order you are stuck
with: get it wrong and the remedy is deleting and rebuilding. Assigning a program change
number to a ZS3 also moves it silently to the end, which is a nasty surprise when that order
is the running order of a show.

This adds a **Position** entry to the ZS3 options menu.

It uses the same param editor the program change number already uses, so a ZS3 can be moved
anywhere in one gesture rather than nudged a step at a time. With thirty or forty ZS3s on a
5" screen that difference matters — moving a ZS3 from the end to third would otherwise be
thirty-odd presses.

## How it works

Reordering is just rebuilding the dictionary with its keys in a new order, so `move_zs3()` is
small. Three things worth a reviewer's eye:

- **`zs3-0` keeps whatever slot it had.** It is not part of the stepping order, and the ZS3
  screen already lists it apart from the saved ZS3s, so it is neither moved nor moveable. The
  rebuild puts the reordered ids back into the non-`zs3-0` slots and leaves that one where it
  was.
- **The entry only appears when there is more than one ZS3** to order, and never for `zs3-0`.
- **Snapshots need no change.** JSON preserves dictionary order in both directions already,
  and stepping follows the new order for free because it reads the same dictionary.

## Tested

The lifted `move_zs3()` and `get_zs3_ids()` were run against stub snapshots covering: moves in
both directions and to either end; `zs3-0` first, in the middle, and absent entirely; that no
entry is lost or replaced; that an unknown id, an unchanged position, and an out-of-range
index are refused or clamped rather than raising; and that a snapshot with one ZS3, only
`zs3-0`, or none at all does not raise.

On a V5.1: a ZS3 moved from the end of a ten-ZS3 set into the middle, then moved several more
times, ends up where the menu says it does; the ZS3 list and the foot pedal agree about the new
order, which is the point of the whole thing; `zs3-0` is untouched and nothing is lost; and the
order survives a round trip out to `last_state.zss` and back.

## Context

@niels raised this on the forum, and suggested that reordering combined with the recent
stepping work may cover
[issue #1056](https://github.com/zynthian/zynthian-issue-tracking/issues/1056) (a registration
sequence with pedal control) without a separate feature: if ZS3s can be reordered, a repeating
sequence is duplicating a ZS3 and moving the copy where you want it, which needs no new state,
no new CUIAs and no editor screen. I think he is right, and this is the smaller half of that
bet. Worth hearing whether you agree before anyone builds the larger half.
