### PR TITLE
Add a way to clone a ZS3 from the ZS3 options menu

### DIFF
--- a/zyngine/zynthian_state_manager.py
+++ b/zyngine/zynthian_state_manager.py
@@ -26,6 +26,7 @@
 import ctypes
 import logging
 import traceback
+from copy import deepcopy
 from glob import glob
 from threading import Thread
 from queue import SimpleQueue
@@ -1777,6 +1778,31 @@ class zynthian_state_manager:
 
         except:
             logging.info("Tried to remove non-existant ZS3")
+
+    def clone_zs3(self, zs3_id, title=None):
+        """Copy a ZS3, placing the copy directly after it
+
+        Saving a new ZS3 stores the *current* state; this copies the state the
+        source ZS3 already holds, so the copy is exact however much has been
+        touched since it was loaded. The copy gets a new 'zs3-N' id and so no
+        program change of its own.
+
+        zs3_id : ZS3 ID to copy
+        title : Title for the copy (Default: autogenerate as for a new ZS3)
+        Returns : ID of the copy, or None if there is nothing to copy
+        """
+
+        if zs3_id == "zs3-0" or zs3_id not in self.zs3:
+            logging.info(f"Can't clone ZS3 '{zs3_id}'")
+            return None
+        index = self.get_next_zs3_index()
+        new_zs3_id = f"zs3-{index}"
+        self.zs3[new_zs3_id] = deepcopy(self.zs3[zs3_id])
+        if not title:
+            title = f"ZS3-{index}"
+        self.zs3[new_zs3_id]["title"] = title
+        self.move_zs3(new_zs3_id, self.get_zs3_ids().index(zs3_id) + 1)
+        return new_zs3_id
 
     def move_zs3(self, zs3_id, index):
         """Move a ZS3 within the stepping order

--- a/zyngui/zynthian_gui_zs3_options.py
+++ b/zyngui/zynthian_gui_zs3_options.py
@@ -64,21 +64,22 @@ class zynthian_gui_zs3_options(zynthian_gui_selector_info):
             self.list_data.append((self.zs3_update, 2, "Overwrite", ["Save current state, overwritting this ZS3.", "zs3_overwrite.png"]))
             self.list_data.append((self.zs3_rename, 3, "Rename", ["Rename this ZS3.", "zs3_rename.png"]))
             self.list_data.append((self.zs3_note, 4, "Note", ["Add a note to this ZS3, shown by the ZS3 performance view.", "zs3_rename.png"]))
+            self.list_data.append((self.zs3_clone, 5, "Clone", ["Copy this ZS3 to a new one, placed just after it.", "zs3_new.png"]))
             if len(self.zyngui.state_manager.get_zs3_ids()) > 1:
-                self.list_data.append((self.zs3_position, 5, f"Position [{self.get_position() + 1}]", ["Move this ZS3 within the order that ZS3_NEXT / ZS3_PREV step through.", "zs3_settings.png"]))
-            self.list_data.append((self.zs3_delete, 6, "Delete", ["Delete this ZS3.", "zs3_delete.png"]))
+                self.list_data.append((self.zs3_position, 6, f"Position [{self.get_position() + 1}]", ["Move this ZS3 within the order that ZS3_NEXT / ZS3_PREV step through.", "zs3_settings.png"]))
+            self.list_data.append((self.zs3_delete, 7, "Delete", ["Delete this ZS3.", "zs3_delete.png"]))
 
             if "/" in self.zs3_id:
                 if self.prog_num:
-                    self.list_data.append((self.zs3_prog_num, 7, f"Program Change Number [{self.prog_num - 1}]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
+                    self.list_data.append((self.zs3_prog_num, 8, f"Program Change Number [{self.prog_num - 1}]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
                 else:
-                    self.list_data.append((self.zs3_prog_num, 7, "Program Change Number [None]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
+                    self.list_data.append((self.zs3_prog_num, 8, "Program Change Number [None]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
                 if self.prog_chan:
-                    self.list_data.append((self.zs3_prog_chan, 8, f"Program Change Channel [{self.prog_chan}]", ["Assign MIDI Program Change channel to this ZS3.", "zs3_overwrite.png"]))
+                    self.list_data.append((self.zs3_prog_chan, 9, f"Program Change Channel [{self.prog_chan}]", ["Assign MIDI Program Change channel to this ZS3.", "zs3_overwrite.png"]))
                 else:
-                    self.list_data.append((self.zs3_prog_chan, 8, "Program Change Channel [Any]", ["Assign MIDI Program Change channel to this ZS3.", "zs3_overwrite.png"]))
+                    self.list_data.append((self.zs3_prog_chan, 9, "Program Change Channel [Any]", ["Assign MIDI Program Change channel to this ZS3.", "zs3_overwrite.png"]))
             elif id != "zs3-0":
-                self.list_data.append((self.zs3_prog_num, 7, "Program Change Number [None]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
+                self.list_data.append((self.zs3_prog_num, 8, "Program Change Number [None]", ["Assign MIDI Program Change number to this ZS3.", "zs3_overwrite.png"]))
             self.preselect_last_action()
         super().fill_list()
 
@@ -203,6 +204,15 @@ class zynthian_gui_zs3_options(zynthian_gui_selector_info):
     def zs3_note_cb(self, note):
         logging.info("Setting note for ZS3 '{}'".format(self.zs3_id))
         self.zyngui.state_manager.set_zs3_note(self.zs3_id, note)
+        self.zyngui.close_screen()
+
+    def zs3_clone(self):
+        title = self.zyngui.state_manager.get_zs3_title(self.zs3_id)
+        self.zyngui.show_keyboard(self.zs3_clone_cb, title)
+
+    def zs3_clone_cb(self, title):
+        logging.info("Cloning ZS3 '{}'".format(self.zs3_id))
+        self.zyngui.state_manager.clone_zs3(self.zs3_id, title)
         self.zyngui.close_screen()
 
     def get_position(self):


### PR DESCRIPTION
Copying a ZS3 today means loading it and using **Save as new ZS3**. That saves the *current*
state rather than the stored one — the same result so long as nothing is touched in between,
but a knocked encoder, a stray CC, or a preset changed while auditioning goes into the copy
silently, and nothing on screen says it happened.

This adds a **Clone** entry to the ZS3 options menu. It copies the ZS3's stored state, asks
for a title the way *Rename* does, and places the copy directly after its source — where a
copy is wanted before it is moved somewhere else with *Position*.

The sequencer already works this way: **Clone phrase**
([`zynthian_gui_mixer.py:2124`](https://github.com/zynthian/zynthian-ui/blob/vangelis/zyngui/zynthian_gui_mixer.py#L2124)
→ `zynseq.duplicate_phrase()`) copies a phrase and drops the copy in beside the original,
because an ordered container is not a filesystem — the order is the running order, and the
same phrase often needs to appear in it twice. A set of ZS3s stepped with `ZS3_NEXT` is that
same kind of container.

## How it works

`clone_zs3()` takes a deep copy of the stored entry, gives it a fresh `zs3-N` id and the
title it was asked for, and reuses `move_zs3()` from #597 to put it directly after its source.
Four things worth a reviewer's eye:

- **The copy has no program change of its own.** A new `zs3-N` id carries none, which is right
  — two ZS3s cannot answer the same program change — and one can be assigned from the same
  menu.
- **`zs3-0` is neither cloneable nor disturbed.** The options menu never offers Clone for it,
  `clone_zs3()` refuses it anyway, and the rebuild inside `move_zs3()` leaves its slot alone.
- **The copy is deep**, so editing the copy's restore flags cannot reach back into the
  original.
- **Snapshots need no change**, and the new ZS3 steps like any other because it is in the same
  dictionary.

The menu entry sits between *Note* and *Position*: clone, then move the copy where it belongs.

## Tested

`clone_zs3()`, `move_zs3()`, `get_zs3_ids()` and `get_next_zs3_index()` were lifted out of the
real file with `ast` and run against stub snapshots — 22 checks covering: the copy landing
after its source when the source is first, last, in the middle, and the only ZS3; two clones
of the same ZS3 getting two ids, neither colliding with an existing `zs3-N`; the given title
used and an absent or empty one autogenerated; the source's title and object left alone; the
nested state copied deeply, so a change to the copy does not reach the original; `zs3-0` and
an unknown id refused with the order unchanged; and `zs3-0` keeping its slot when it is first,
in the middle, and absent.

On a V5.1, cloning a cue from a set of ten: the copy appears directly after its source in
the ZS3 list, carries no program change, and sounds identical; the foot pedal steps through
both; editing one leaves the other alone; and it survives a round trip out to
`last_state.zss` and back. Comparing the stored entries afterwards, the copy differs from its
source in the title and nothing else.

## Note

Independent of #598 — the two touch different methods of the same file and merge cleanly in
either order.
