### PR TITLE
Route OSC mixer feedback to heartbeat source ports

### DIFF
--- a/zyngine/zynthian_engine_audio_mixer.py
+++ b/zyngine/zynthian_engine_audio_mixer.py
@@ -102,6 +102,12 @@ class zynmixer(zynthian_engine):
         self.lib_zynmixer.enableDpm.argtypes = [
             ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
 
+        self.lib_zynmixer.addOscClient.argtypes = [
+            ctypes.c_char_p, ctypes.c_uint16]
+        self.lib_zynmixer.addOscClient.restype = ctypes.c_int
+        self.lib_zynmixer.removeOscClient.argtypes = [
+            ctypes.c_char_p, ctypes.c_uint16]
+
         self.lib_zynmixer.getMaxChannels.restype = ctypes.c_uint8
 
         self.MAX_NUM_CHANNELS = self.lib_zynmixer.getMaxChannels()
@@ -550,14 +556,17 @@ class zynmixer(zynthian_engine):
 
     # Function to add OSC client registration
     # client: IP address of OSC client
-    def add_osc_client(self, client):
-        return self.lib_zynmixer.addOscClient(ctypes.c_char_p(client.encode('utf-8')))
+    # port: UDP port of OSC client
+    def add_osc_client(self, client, port):
+        return self.lib_zynmixer.addOscClient(
+            ctypes.c_char_p(client.encode('utf-8')), port)
 
     # Function to remove OSC client registration
     # client: IP address of OSC client
-    def remove_osc_client(self, client):
+    # port: UDP port of OSC client
+    def remove_osc_client(self, client, port):
         self.lib_zynmixer.removeOscClient(
-            ctypes.c_char_p(client.encode('utf-8')))
+            ctypes.c_char_p(client.encode('utf-8')), port)
 
     # --------------------------------------------------------------------------
     # State management (for snapshots)

--- a/zyngui/zynthian_gui.py
+++ b/zyngui/zynthian_gui.py
@@ -394,15 +394,16 @@ class zynthian_gui:
             self.state_manager.set_event_flag()
             part2 = parts[2]
             if part2 in ("HEARTBEAT", "SETUP"):
-                if src.hostname not in self.osc_clients:
+                client = (src.hostname, int(src.port))
+                if client not in self.osc_clients:
                     try:
-                        if self.state_manager.zynmixer.add_osc_client(src.hostname) < 0:
-                            logging.warning("Failed to add OSC client registration {}".format(src.hostname))
+                        if self.state_manager.zynmixer.add_osc_client(*client) < 0:
+                            logging.warning("Failed to add OSC client registration {}:{}".format(*client))
                             return
                     except:
-                        logging.warning("Error trying to add OSC client registration {}".format(src.hostname))
+                        logging.warning("Error trying to add OSC client registration {}:{}".format(*client))
                         return
-                self.osc_clients[src.hostname] = monotonic()
+                self.osc_clients[client] = monotonic()
                 self.state_manager.zynmixer.enable_dpm(0, self.state_manager.zynmixer.MAX_NUM_CHANNELS - 2, True)
             else:
                 if part2[:6] == "VOLUME":
@@ -2583,7 +2584,7 @@ class zynthian_gui:
                 if self.osc_clients[client] < self.watchdog_last_check - self.osc_heartbeat_timeout:
                     self.osc_clients.pop(client)
                     try:
-                        self.state_manager.zynmixer.remove_osc_client(client)
+                        self.state_manager.zynmixer.remove_osc_client(*client)
                     except:
                         pass
 

--- a/zynlibs/zynmixer/mixer.c
+++ b/zynlibs/zynmixer/mixer.c
@@ -349,7 +349,7 @@ int init() {
     for (uint8_t i = 0; i < MAX_OSC_CLIENTS; ++i) {
         memset(g_oscClient[i].sin_zero, '\0', sizeof g_oscClient[i].sin_zero);
         g_oscClient[i].sin_family      = AF_INET;
-        g_oscClient[i].sin_port        = htons(1370);
+        g_oscClient[i].sin_port        = 0;
         g_oscClient[i].sin_addr.s_addr = 0;
     }
 
@@ -690,16 +690,25 @@ void enableDpm(uint8_t start, uint8_t end, uint8_t enable) {
     }
 }
 
-int addOscClient(const char* client) {
+int addOscClient(const char* client, uint16_t port) {
+    struct in_addr address;
+    if (port == 0 || inet_pton(AF_INET, client, &address) != 1) {
+        fprintf(stderr, "libzynmixer: Failed to register client %s:%u\n", client, (unsigned int)port);
+        return -1;
+    }
+
+    for (uint8_t i = 0; i < MAX_OSC_CLIENTS; ++i) {
+        if (g_oscClient[i].sin_addr.s_addr == address.s_addr &&
+            g_oscClient[i].sin_port == htons(port))
+            return i;
+    }
+
     for (uint8_t i = 0; i < MAX_OSC_CLIENTS; ++i) {
         if (g_oscClient[i].sin_addr.s_addr != 0)
             continue;
-        if (inet_pton(AF_INET, client, &(g_oscClient[i].sin_addr)) != 1) {
-            g_oscClient[i].sin_addr.s_addr = 0;
-            fprintf(stderr, "libzynmixer: Failed to register client %s\n", client);
-            return -1;
-        }
-        fprintf(stderr, "libzynmixer: Added OSC client %d: %s\n", i, client);
+        g_oscClient[i].sin_addr = address;
+        g_oscClient[i].sin_port = htons(port);
+        fprintf(stderr, "libzynmixer: Added OSC client %d: %s:%u\n", i, client, (unsigned int)port);
         for (int nChannel = 0; nChannel < MAX_CHANNELS; ++nChannel) {
             setBalance(nChannel, getBalance(nChannel));
             setLevel(nChannel, getLevel(nChannel));
@@ -715,19 +724,22 @@ int addOscClient(const char* client) {
         g_bOsc = 1;
         return i;
     }
-    fprintf(stderr, "libzynmixer: Not adding OSC client %s - Maximum client count reached [%d]\n", client, MAX_OSC_CLIENTS);
+    fprintf(stderr, "libzynmixer: Not adding OSC client %s:%u - Maximum client count reached [%d]\n",
+            client, (unsigned int)port, MAX_OSC_CLIENTS);
     return -1;
 }
 
-void removeOscClient(const char* client) {
-    char pClient[sizeof(struct in_addr)];
-    if (inet_pton(AF_INET, client, pClient) != 1)
+void removeOscClient(const char* client, uint16_t port) {
+    struct in_addr address;
+    if (port == 0 || inet_pton(AF_INET, client, &address) != 1)
         return;
     g_bOsc = 0;
     for (uint8_t i = 0; i < MAX_OSC_CLIENTS; ++i) {
-        if (memcmp(pClient, &g_oscClient[i].sin_addr.s_addr, 4) == 0) {
+        if (g_oscClient[i].sin_addr.s_addr == address.s_addr &&
+            g_oscClient[i].sin_port == htons(port)) {
             g_oscClient[i].sin_addr.s_addr = 0;
-            fprintf(stderr, "libzynmixer: Removed OSC client %d: %s\n", i, client);
+            g_oscClient[i].sin_port        = 0;
+            fprintf(stderr, "libzynmixer: Removed OSC client %d: %s:%u\n", i, client, (unsigned int)port);
         }
         if (g_oscClient[i].sin_addr.s_addr != 0)
             g_bOsc = 1;

--- a/zynlibs/zynmixer/mixer.h
+++ b/zynlibs/zynmixer/mixer.h
@@ -192,15 +192,17 @@ void enableDpm(uint8_t start, uint8_t end, uint8_t enable);
 
 /** @brief  Adds client to list of registered OSC clients
  *   @param  client IP address of client
+ *   @param  port UDP port of client
  *   @retval int Index of client or -1 on failure
  *   @note   Clients get all updates including DPM
  */
-int addOscClient(const char* client);
+int addOscClient(const char* client, uint16_t port);
 
 /** @brief  Removes client from list of registered OSC clients
  *   @param  client IP address of client
+ *   @param  port UDP port of client
  */
-void removeOscClient(const char* client);
+void removeOscClient(const char* client, uint16_t port);
 
 /** @brief Get maximum quantity of channels
  *   @retval size_t Maximum quantity of channels


### PR DESCRIPTION
A `/mixer/heartbeat` currently registers only `src.hostname`, and the native mixer preconfigures every OSC feedback endpoint with UDP port 1370. Two controllers on the same host therefore collapse into one registration, and changing `--osc-port` cannot redirect feedback.

This tracks clients as `(hostname, source port)` throughout the Oram feedback path:

- the GUI registry uses the heartbeat sender's actual port
- the ctypes wrapper passes that port to the native mixer
- the native endpoint table sends to each registered host-port pair
- timeout removal deletes only the expired endpoint, leaving other ports on the same host active
- duplicate heartbeats for one endpoint remain idempotent

This targets `oram`, where the native OSC feedback path from the report is still present. The later `vangelis` branch removed native feedback and needs a separate migration decision.

BCL evidence: https://github.com/iibaranov-IG/broadcast-control-lab/pull/1

The executable case pins Oram revision `11d4e858367db465a431c701d9035432742a5a7d`, confirms the baseline host-only/fixed-1370 behavior, compiles the patched native sender, and verifies exact OSC datagrams at two independent loopback ports. After removing the first endpoint, the second continues receiving feedback.

Validation:
- Python syntax compilation
- native mixer OSC sender compiled with a JACK test stub
- two-port UDP routing and exact endpoint removal pass under Node 22.20.0
- three repeated loopback runs pass

Hardware verification remains pending. The reporter's three-Zynthian setup can complete it by using distinct `--osc-port` values and confirming fader, mute and DPM feedback at every controller.

Fixes zynthian/zynthian-issue-tracking#1530.
